### PR TITLE
Feature/live widget datasets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,7 +226,6 @@ tmp/
 
 # Planning scratch files
 plans/
-notebooks/
 scratchbook.md
 CHANGELOG_STAGING.md
 

--- a/README.md
+++ b/README.md
@@ -1,132 +1,41 @@
 # genome-spy-python
 
-`genome-spy-python` is a Python wrapper for
-[GenomeSpy](https://github.com/genome-spy/genome-spy).
+`genome-spy-python` is a Python interface for [GenomeSpy], a grammar for
+interactive and scalable genomic visualization. It lets Python users build
+GenomeSpy specifications with a declarative, fluent API, serialize them to
+JSON, and display them in Jupyter notebooks.
 
-The goal is to let Python users author GenomeSpy specifications with an
-idiomatic Python API, serialize them to valid GenomeSpy JSON, and render them
-in notebooks. The public API aims to mirror Altair-style authoring where it
-fits GenomeSpy naturally, while still exposing genomics-native features such as
-locus-scaled axes and lazy genomic data sources.
+[Altair] is the project's main source of inspiration. This codebase follows
+Altair's approach of combining schema-backed specification objects with a small
+handwritten Python API for marks, encodings, composition, and rendering. It
+adapts that model to GenomeSpy's genomics-native grammar: locus scales, genomic
+data sources, and coordinated genomic views.
 
-## Contributing
+The project is under active development. The current focus is the reusable
+GenomeSpy Core grammar and notebook rendering; GenomeSpy App-specific features
+will come later.
 
-### Set up the repository
+## Installation
 
-Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/), then
-clone the repository and install the development and documentation dependencies:
+The package requires Python 3.11 or newer. Until a package release is
+published, install it from source with [uv]:
 
 ```bash
 git clone https://github.com/genome-spy/genome-spy-python.git
 cd genome-spy-python
-uv sync --group dev --group docs
+uv sync
 ```
 
-The project requires Python 3.11 or newer. The `uv sync` command installs the
-package in editable mode, so changes under `src/` are immediately available to
-tests, notebooks, and documentation examples.
-
-Run the basic verification suite from the repository root:
+For dataframe-backed charts using Arrow transport, install the optional extra:
 
 ```bash
-uv run pytest tests/ -x
-uv run ruff check .
-uv run ruff format --check .
-uv run mypy src/
+uv sync --extra arrow
 ```
 
-To install the repository's pre-commit hooks and run them manually:
+## Examples
 
-```bash
-uv run pre-commit install
-uv run pre-commit run --all-files
-```
-
-### Build and preview the documentation
-
-Build the HTML documentation with:
-
-```bash
-uv run sphinx-build -b html -W --keep-going docs docs/_build/html
-```
-
-The Sphinx build imports the examples, validates their serialized GenomeSpy
-specifications, and generates the gallery pages and downloadable specs. Preview
-the result locally with:
-
-```bash
-python3 -m http.server 8000 --directory docs/_build/html
-```
-
-Then open <http://localhost:8000/> in a browser. The live examples load the
-pinned GenomeSpy JavaScript bundle from the CDN, so an internet connection is
-needed when viewing interactive charts. Gallery cards require manually reviewed
-PNG thumbnails to exist before the build.
-
-### Work on examples
-
-Documentation examples live under `docs/examples/` and are the source of truth
-for the generated gallery. Add or update an example there, then rebuild the
-documentation and run the gallery tests:
-
-```bash
-uv run pytest tests/test_docs_gallery.py -q
-uv run sphinx-build -b html -W --keep-going docs docs/_build/html
-```
-
-### Regenerate schema wrappers
-
-Generated schema wrappers are committed to the repository. Maintainers should
-regenerate them when the pinned GenomeSpy core version changes:
-
-```bash
-uv run python tools/generate_schema_wrapper.py
-```
-
-Schema regeneration requires `npm` on `PATH` and updates the generated schema
-package from the pinned `@genome-spy/core` release. See
-[Schema Generation](#schema-generation) for local upstream audit modes.
-
-## Notebook Usage
-
-The current notebook path uses `anywidget` as a thin bridge to GenomeSpy's
-JavaScript `embed(...)` API:
-
-```python
-import genome_spy as gs
-
-chart = (
-    gs.Chart(data=[{"x": 1, "y": 2, "category": "A"}])
-    .mark_point(size=90)
-    .encode(
-        x=gs.X("x:Q"),
-        y=gs.Y("y:Q"),
-        color=gs.Color("category:N"),
-    )
-)
-
-chart
-```
-
-A runnable example notebook is available at
-`notebooks/basic_point_chart.ipynb`.
-
-`chart.widget()` is also available for explicit `anywidget` usage, but plain
-`chart` display is the most portable default across notebook frontends.
-
-Existing GenomeSpy specifications can be validated, wrapped, and rendered
-without rewriting them:
-
-```python
-chart = gs.TopLevelSpec.from_dict(spec)
-```
-
-The loader dispatches unit, layer, multiscale, and concatenated roots, including
-template or URL imports nested inside compositions.
-
-## Example notebooks
-
-Some notebooks use simple tabular data to show the core authoring model:
+Build a simple scatter plot from Python records. In a notebook, evaluate the
+last line to display the interactive chart.
 
 ```python
 import genome_spy as gs
@@ -134,93 +43,126 @@ import genome_spy as gs
 chart = (
     gs.Chart(
         [
-            {"x": 1.0, "y": 4.2, "category": "A"},
-            {"x": 2.0, "y": 3.1, "category": "B"},
-            {"x": 3.0, "y": 5.0, "category": "A"},
+            {"x": 1, "y": 4, "group": "A"},
+            {"x": 2, "y": 3, "group": "B"},
+            {"x": 3, "y": 5, "group": "A"},
         ]
     )
-    .mark_circle()
+    .mark_point(size=80)
     .encode(
-        gs.X("x:Q").scale(zero=False),
-        gs.Y("y:Q").scale(zero=False, padding=1),
-        color=gs.Color("category:N"),
+        x="x:Q",
+        y="y:Q",
+        color="group:N",
     )
 )
 
 chart
 ```
 
-GenomeSpy-specific genomic helpers such as
-`gs.Locus("chrom", "start")` remain available for locus-scaled genomic axes.
-For top-level chart config, prefer the generated fluent methods such as
-`chart.configure_view(...)` and `chart.configure_axis(...)`; helper constructors
-like `gs.config(...)` and `gs.view_config(...)` remain available when you want
-to build schema objects directly. Small mapping helpers such as `gs.scales(...)`
-and ergonomic builders such as `gs.param(...)` also remain useful where they
-keep the visualization code shorter and clearer.
+GenomeSpy also has locus-scaled axes for genomic coordinates. This small
+example renders intervals along a region of chromosome 1:
 
-## Dataframe rendering
+```python
+import genome_spy as gs
 
-When a chart is displayed in a notebook or generated for the documentation
-gallery, Polars dataframes are transferred automatically as uncompressed Arrow
-IPC. pandas dataframes and PyArrow tables use the same path when the optional
-Arrow support is installed:
+intervals = [
+    {"chrom": "chr1", "start": 100, "end": 220, "name": "gene A"},
+    {"chrom": "chr1", "start": 280, "end": 420, "name": "gene B"},
+]
 
-```bash
-pip install "genome-spy-python[arrow]"
+chart = (
+    gs.Chart(intervals)
+    .mark_rect()
+    .encode(
+        x=gs.Locus("chrom", "start"),
+        x2="end:Q",
+        y="name:N",
+        color="name:N",
+    )
+)
+
+chart
 ```
 
-No manual `arrow://` data source or widget buffer map is needed. Ordinary
-Python record lists, and pandas installations without PyArrow, continue to use
-inline JSON. `chart.to_dict()`, `chart.to_json()`, and saved specs always
-remain JSON-compatible.
+Charts can be serialized to a portable GenomeSpy specification or standalone
+HTML:
 
-GenomeSpy currently decodes IPC into JavaScript row objects, so this is binary
-columnar transport rather than zero-copy rendering. Use uncompressed IPC; dates
-and timestamps follow GenomeSpy's normal JavaScript conversion behavior, and
-integers beyond JavaScript's safe integer range can lose precision.
+```python
+chart.to_json()
+chart.save("intervals.html")
+```
 
-## Packaged Datasets
+See the [documentation sources](docs/) for more examples and API reference
+material.
 
-A small set of datasets used by the documentation examples is available through
-`genome_spy.datasets.load_dataset(...)`.
+### Update data without recreating the chart
 
-## Schema Generation
+For reactive notebooks, create a widget with an explicitly named dataset and
+replace that dataset as inputs change. The browser keeps the existing
+GenomeSpy instance, so view state such as zoom is preserved.
 
-Generated schema wrappers are committed to git and shipped with the package,
-so normal users installing `genome-spy-python` do not need npm.
+```python
+chart = gs.Chart(data={"name": "table"}, datasets={"table": []})
+view = chart.widget()
 
-Maintainers regenerate wrappers only when updating the pinned GenomeSpy core
-version:
+view.set_dataset("table", updated_dataframe)
+```
+
+Install the Arrow extra when updating from Polars, pandas, or PyArrow tables:
+
+```bash
+uv sync --extra arrow
+```
+
+## Contributing
+
+Contributions are welcome. Set up the repository with its development and
+documentation dependencies, then run the checks before opening a pull request:
+
+```bash
+uv sync --group dev --group docs
+uv run pytest tests/ -x
+uv run ruff check .
+uv run ruff format --check .
+uv run mypy src/
+```
+
+The source lives in `src/genome_spy/`, tests are in `tests/`, and documentation
+examples are in `docs/examples/`. Generated schema wrappers are committed; only
+regenerate them when updating the pinned GenomeSpy Core version:
 
 ```bash
 uv run python tools/generate_schema_wrapper.py
 ```
 
-That command requires `npm` on `PATH`, fetches the version-pinned
-`@genome-spy/core` package temporarily, writes `src/genome_spy/schema/`, and
-then updates the generated schema package in-place. It also writes a capability
-manifest used to verify that generated transforms and root specification
-variants remain covered.
+### Build the documentation
 
-To audit a built local GenomeSpy core package without fetching npm, generate
-into a separate output directory:
+Build the documentation site from the repository root:
 
 ```bash
-uv run python tools/generate_schema_wrapper.py \
-  --package-dir <path-to-genome-spy>/packages/core \
-  --output-dir <audit-output>
+uv run sphinx-build -b html -W --keep-going docs docs/_build/html
 ```
 
-An explicit schema file can be inspected in the same way:
+Preview the result locally with:
 
 ```bash
-uv run python tools/generate_schema_wrapper.py \
-  --schema-path <path-to-schema.json> \
-  --core-version <schema-version> \
-  --output-dir <audit-output> \
-  --spec-reference-dir ""
+python3 -m http.server 8000 --directory docs/_build/html
 ```
 
-The default npm mode remains the release source of truth. Local modes are for
-checking unreleased upstream changes before updating the pinned core version.
+Then open <http://localhost:8000/>. Interactive examples load the GenomeSpy
+JavaScript bundle from a CDN, so viewing them requires an internet connection.
+
+For the project's design and current implementation direction, see the
+[`plans/`](plans/) directory.
+
+## References
+
+- [GenomeSpy] — the upstream visualization grammar and JavaScript renderer.
+- [Altair] — the primary design inspiration for this Python API.
+- [Gosling] — a related grammar and Python-wrapper design reference for
+  genomics visualization.
+
+[Altair]: https://altair-viz.github.io/
+[GenomeSpy]: https://genome-spy.org/
+[Gosling]: https://gosling-lang.org/
+[uv]: https://docs.astral.sh/uv/

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,26 @@ chart
 In a Jupyter notebook, displaying `chart` renders a live, interactive GenomeSpy
 view. `chart.widget()` returns an explicit `anywidget` instance if you need one.
 
+## Updating a live dataset
+
+For reactive notebooks, declare a named dataset, construct the widget once in a
+stable cell, and update that same widget from downstream cells. Supported
+dataframes and tables use Arrow IPC automatically:
+
+```python
+view = (
+    gs.Chart(data={"name": "table"}, datasets={"table": []})
+    .mark_point()
+    .encode(x="x:Q", y="y:Q")
+    .widget()
+)
+view.set_dataset("table", dataframe)
+```
+
+`set_dataset()` keeps the embedded GenomeSpy instance and its interaction state
+alive. When the widget has exactly one live dataset, `view.set_data(dataframe)`
+is a convenient equivalent.
+
 ## Serializing a spec
 
 ```python

--- a/notebooks/genome_spy_arrow_reactive.py
+++ b/notebooks/genome_spy_arrow_reactive.py
@@ -1,0 +1,96 @@
+"""Live Polars-to-GenomeSpy updates in Marimo without widget reconstruction."""
+
+import marimo
+
+__generated_with = "0.23.16"
+app = marimo.App()
+
+
+@app.cell
+def _():
+    import genome_spy as gs
+    import marimo as mo
+    import polars as pl
+
+    return gs, mo, pl
+
+
+@app.cell
+def _(mo):
+    amplitude = mo.ui.slider(
+        start=50,
+        stop=200,
+        value=100,
+        step=10,
+        label="Signal amplitude (%)",
+    )
+    return (amplitude,)
+
+
+@app.cell
+def _(gs, mo, pl):
+    initial_signal = pl.DataFrame(
+        {
+            "position": list(range(8)),
+            "value": [0.2, 0.8, 1.4, 0.6, 1.1, 1.8, 1.2, 0.4],
+            "group": ["A", "A", "A", "A", "B", "B", "B", "B"],
+        }
+    )
+    chart = (
+        gs.Chart(data={"name": "table"}, datasets={"table": []})
+        .mark_point(size=110, filled=True)
+        .encode(
+            x=gs.X("position:Q").title("Position"),
+            y=gs.Y("value:Q").title("Scaled value"),
+            color=gs.Color("group:N"),
+            tooltip=[
+                gs.Tooltip("position:Q"),
+                gs.Tooltip("value:Q"),
+                gs.Tooltip("group:N"),
+            ],
+        )
+        .properties(width=620, height=320)
+    )
+    view = chart.widget()
+    view.set_dataset("table", initial_signal)
+    chart_widget = mo.ui.anywidget(view)
+    return chart_widget, view
+
+
+@app.cell
+def _(amplitude, mo, pl, view):
+    filtered_dataframe = pl.DataFrame(
+        {
+            "position": list(range(8)),
+            "value": [0.2, 0.8, 1.4, 0.6, 1.1, 1.8, 1.2, 0.4],
+            "group": ["A", "A", "A", "A", "B", "B", "B", "B"],
+        }
+    ).with_columns((pl.col("value") * amplitude.value / 100).alias("value"))
+    view.set_dataset("table", filtered_dataframe)
+    transport_summary = mo.md(
+        "**Live Arrow update:** the stable widget model received a new binary "
+        'dataset through `view.set_dataset("table", filtered_dataframe)`; '
+        "the chart was not reconstructed."
+    )
+    return (transport_summary,)
+
+
+@app.cell
+def _(amplitude, chart_widget, mo, transport_summary):
+    mo.vstack(
+        [
+            amplitude,
+            transport_summary,
+            chart_widget,
+        ]
+    )
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ artifacts = [
 ]
 
 [tool.genome-spy]
-core-version = "0.82.0"
+core-version = "0.83.1"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/genome_spy/_render.py
+++ b/src/genome_spy/_render.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from dataclasses import dataclass, field
 from hashlib import sha256
-from typing import Any, Callable, Protocol
+from typing import Any, Callable, Literal, Protocol
 
 from genome_spy._chart_authoring import normalize_data
 from genome_spy.arrow import _try_to_arrow_ipc
@@ -16,6 +17,28 @@ class _PreparedSpec:
 
     spec: dict[str, Any]
     buffers: dict[str, bytes]
+
+
+_DatasetFormat = Literal["arrow", "records"]
+
+
+@dataclass(frozen=True, slots=True)
+class _LiveDataset:
+    """One named dataset synchronized by a live notebook widget."""
+
+    name: str
+    owner: str | None
+    scoped: bool
+    initial_payload: bytes | None
+    initial_format: _DatasetFormat | None
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedWidget:
+    """A runtime spec and its live named-dataset declarations."""
+
+    spec: dict[str, Any]
+    datasets: tuple[_LiveDataset, ...]
 
 
 class _RenderSerializable(Protocol):
@@ -63,3 +86,119 @@ def prepare_render(chart: _RenderSerializable) -> _PreparedSpec:
         normalize_chart_data=context.normalize_data,
     )
     return _PreparedSpec(spec=spec, buffers=context.buffers)
+
+
+def prepare_widget(chart: _RenderSerializable) -> _PreparedWidget:
+    """Prepare a chart for live named-dataset widget updates."""
+    return prepare_widget_spec(prepare_render(chart))
+
+
+def prepare_widget_spec(prepared: _PreparedSpec) -> _PreparedWidget:
+    """Rewrite known eager sources in a prepared spec as named datasets."""
+    spec = deepcopy(prepared.spec)
+    root_datasets = spec.setdefault("datasets", {})
+    if not isinstance(root_datasets, dict):
+        raise TypeError("GenomeSpy root datasets must be a mapping.")
+
+    used_names = _declared_dataset_names(spec)
+    generated_names: dict[str, str] = {}
+    datasets: list[_LiveDataset] = []
+
+    def register(
+        name: str,
+        *,
+        owner: str | None,
+        scoped: bool,
+        initial_payload: bytes | None = None,
+        initial_format: _DatasetFormat | None = None,
+    ) -> None:
+        datasets.append(
+            _LiveDataset(
+                name=name,
+                owner=owner,
+                scoped=scoped,
+                initial_payload=initial_payload,
+                initial_format=initial_format,
+            )
+        )
+
+    def generated_name(token: str) -> str:
+        existing = generated_names.get(token)
+        if existing is not None:
+            return existing
+        index = len(generated_names)
+        candidate = f"__genome_spy_python_data_{index}"
+        while candidate in used_names:
+            index += 1
+            candidate = f"__genome_spy_python_data_{index}"
+        used_names.add(candidate)
+        generated_names[token] = candidate
+        return candidate
+
+    def visit(value: Any, *, owner: str | None, scoped: bool) -> None:
+        if isinstance(value, list):
+            for item in value:
+                visit(item, owner=owner, scoped=scoped)
+            return
+        if not isinstance(value, dict):
+            return
+
+        current_owner = owner
+        current_scoped = scoped
+        if value is not spec and "datasets" in value:
+            current_scoped = True
+            name = value.get("name")
+            current_owner = name if isinstance(name, str) and name else None
+
+        declared = value.get("datasets")
+        if isinstance(declared, dict):
+            for name in declared:
+                if isinstance(name, str) and name:
+                    register(name, owner=current_owner, scoped=current_scoped)
+
+        data = value.get("data")
+        if isinstance(data, dict):
+            url = data.get("url")
+            if isinstance(url, str) and url.startswith("arrow://"):
+                token = url.removeprefix("arrow://")
+                payload = prepared.buffers.get(token)
+                if payload is None:
+                    raise ValueError(f"No Arrow IPC payload provided for {token}.")
+                name = generated_name(token)
+                if name not in root_datasets:
+                    root_datasets[name] = []
+                    register(
+                        name,
+                        owner=None,
+                        scoped=False,
+                        initial_payload=payload,
+                        initial_format="arrow",
+                    )
+                value["data"] = {"name": name}
+            elif set(data) == {"values"} and isinstance(data["values"], list):
+                name = generated_name(f"records:{len(generated_names)}")
+                root_datasets[name] = data["values"]
+                register(name, owner=None, scoped=False)
+                value["data"] = {"name": name}
+
+        for key, child in value.items():
+            if key not in {"data", "datasets"}:
+                visit(child, owner=current_owner, scoped=current_scoped)
+
+    visit(spec, owner=None, scoped=False)
+    return _PreparedWidget(spec=spec, datasets=tuple(datasets))
+
+
+def _declared_dataset_names(value: Any) -> set[str]:
+    """Return all existing named-dataset keys in a serialized spec."""
+    names: set[str] = set()
+    if isinstance(value, list):
+        for item in value:
+            names.update(_declared_dataset_names(item))
+    elif isinstance(value, dict):
+        datasets = value.get("datasets")
+        if isinstance(datasets, dict):
+            names.update(name for name in datasets if isinstance(name, str))
+        for child in value.values():
+            names.update(_declared_dataset_names(child))
+    return names

--- a/src/genome_spy/_widget.py
+++ b/src/genome_spy/_widget.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, cast
 
 import anywidget
 import traitlets
 
+from genome_spy._chart_authoring import json_safe, records_from_data
+from genome_spy._render import _PreparedSpec, prepare_widget_spec
+from genome_spy.arrow import to_arrow_ipc
 from genome_spy.chart import DEFAULT_EMBED_URL
 
 _ESM_PATH = Path(__file__).with_name("static") / "widget.js"
+_DatasetFormat = Literal["arrow", "records"]
 
 
 class JupyterChart(anywidget.AnyWidget):
@@ -22,7 +26,9 @@ class JupyterChart(anywidget.AnyWidget):
     spec = traitlets.Dict().tag(sync=True)
     bundle_url = traitlets.Unicode(DEFAULT_EMBED_URL).tag(sync=True)
     embed_options = traitlets.Dict(default_value={}).tag(sync=True)
-    arrow_data = traitlets.Dict(default_value={}).tag(sync=True)
+    dataset_manifest = traitlets.List(trait=traitlets.Dict(), default_value=[]).tag(
+        sync=True
+    )
     parameter_names = traitlets.List(trait=traitlets.Unicode(), default_value=[]).tag(
         sync=True
     )
@@ -43,22 +49,189 @@ class JupyterChart(anywidget.AnyWidget):
         enable_click_events: bool = False,
         **kwargs: Any,
     ) -> None:
-        arrow_data: dict[str, bytes]
-        if hasattr(chart, "_prepare_render"):
-            prepared = chart._prepare_render()
-            spec = prepared.spec
-            arrow_data = prepared.buffers
+        if hasattr(chart, "_prepare_widget"):
+            prepared = chart._prepare_widget()
         else:
-            spec = dict(chart)
-            arrow_data = {}
+            prepared = prepare_widget_spec(_PreparedSpec(spec=dict(chart), buffers={}))
+
+        manifest: list[dict[str, Any]] = []
+        for index, dataset in enumerate(prepared.datasets):
+            prefix = f"_dataset_{index}"
+            manifest.append(
+                {
+                    "name": dataset.name,
+                    "owner": dataset.owner,
+                    "scoped": dataset.scoped,
+                    "payload_trait": f"{prefix}_payload",
+                    "format_trait": f"{prefix}_format",
+                    "revision_trait": f"{prefix}_revision",
+                    "initial_payload": dataset.initial_payload,
+                    "initial_format": dataset.initial_format,
+                }
+            )
 
         super().__init__(
-            spec=spec,
+            spec=prepared.spec,
             bundle_url=bundle_url,
             embed_options=embed_options or {},
-            arrow_data=arrow_data,
+            dataset_manifest=[self._manifest_entry(entry) for entry in manifest],
             parameter_names=list(parameter_names),
             parameter_values=dict(parameter_values or {}),
             enable_click_events=enable_click_events,
             **kwargs,
         )
+
+        for entry in manifest:
+            initial_payload = entry["initial_payload"]
+            initial_format = entry["initial_format"] or "records"
+            self.add_traits(
+                **{
+                    entry["payload_trait"]: traitlets.Any(initial_payload).tag(
+                        sync=True
+                    ),
+                    entry["format_trait"]: traitlets.Unicode(initial_format).tag(
+                        sync=True
+                    ),
+                    entry["revision_trait"]: traitlets.Int(
+                        1 if initial_payload is not None else 0
+                    ).tag(sync=True),
+                }
+            )
+
+    @property
+    def dataset_names(self) -> tuple[str, ...]:
+        """Return live dataset names in declaration order.
+
+        Description:
+            Names are taken from the widget's fixed runtime dataset manifest.
+            Repeated names indicate scoped declarations and require a unique
+            name before they can be addressed through :meth:`set_dataset`.
+
+        Returns:
+            Dataset names in declaration order.
+
+        Raises:
+            No exceptions are raised directly here.
+
+        Example:
+            >>> chart.widget().dataset_names
+            ('table',)
+        """
+        return tuple(str(entry["name"]) for entry in self.dataset_manifest)
+
+    def set_dataset(
+        self,
+        name: str,
+        data: object,
+        *,
+        format: _DatasetFormat = "arrow",
+    ) -> None:
+        """Replace one declared live dataset without recreating GenomeSpy.
+
+        Description:
+            Arrow is the default and transfers supported dataframe/table inputs
+            as a binary AnyWidget buffer. Use ``format="records"`` only for
+            ordinary JSON-compatible record lists.
+
+        Args:
+            name: Declared dataset name.
+            data: Table or records used as the replacement value.
+            format: Transport format, either ``"arrow"`` or ``"records"``.
+
+        Returns:
+            ``None`` after the synchronized transport state has been updated.
+
+        Raises:
+            KeyError: If no declared dataset has ``name``.
+            ValueError: If ``name`` is ambiguous or cannot be addressed.
+            TypeError: If ``data`` cannot be serialized using ``format``.
+
+        Example:
+            >>> view.set_dataset('table', dataframe)
+        """
+        entry = self._dataset_entry(name)
+        payload = self._serialize_dataset(data, format)
+        revision_trait = cast(str, entry["revision_trait"])
+        with self.hold_sync():
+            setattr(self, cast(str, entry["payload_trait"]), payload)
+            setattr(self, cast(str, entry["format_trait"]), format)
+            setattr(self, revision_trait, getattr(self, revision_trait) + 1)
+
+    def set_data(
+        self,
+        data: object,
+        *,
+        format: _DatasetFormat = "arrow",
+    ) -> None:
+        """Replace the only declared live dataset.
+
+        Description:
+            This is a convenience alias for :meth:`set_dataset` when the widget
+            has exactly one live dataset.
+
+        Args:
+            data: Table or records used as the replacement value.
+            format: Transport format, either ``"arrow"`` or ``"records"``.
+
+        Returns:
+            ``None`` after the synchronized transport state has been updated.
+
+        Raises:
+            ValueError: If the widget has zero or multiple live datasets.
+            TypeError: If ``data`` cannot be serialized using ``format``.
+
+        Example:
+            >>> view.set_data(dataframe)
+        """
+        if len(self.dataset_manifest) != 1:
+            names = ", ".join(self.dataset_names) or "none"
+            raise ValueError(
+                "set_data() requires exactly one live dataset; "
+                f"available datasets: {names}."
+            )
+        self.set_dataset(str(self.dataset_manifest[0]["name"]), data, format=format)
+
+    def _dataset_entry(self, name: str) -> dict[str, Any]:
+        """Return the unambiguous manifest entry for a public dataset name."""
+        matches = [entry for entry in self.dataset_manifest if entry["name"] == name]
+        if not matches:
+            available = ", ".join(self.dataset_names) or "none"
+            raise KeyError(
+                f"Unknown dataset {name!r}. Available datasets: {available}."
+            )
+        if len(matches) != 1:
+            raise ValueError(
+                f"Dataset {name!r} is declared in multiple scopes and cannot be "
+                "addressed by name alone."
+            )
+        entry = dict(matches[0])
+        if entry["scoped"] and entry["owner"] is None:
+            raise ValueError(
+                f"Dataset {name!r} is declared in an unnamed nested view. "
+                "Give its owner view a unique name before updating it."
+            )
+        return entry
+
+    @staticmethod
+    def _manifest_entry(entry: Mapping[str, Any]) -> dict[str, Any]:
+        """Return synchronized metadata without Python-only initial values."""
+        return {
+            key: value
+            for key, value in entry.items()
+            if key not in {"initial_payload", "initial_format"}
+        }
+
+    @staticmethod
+    def _serialize_dataset(data: object, format: _DatasetFormat) -> bytes | list[Any]:
+        """Serialize one dataset before mutating synchronized trait state."""
+        if format == "arrow":
+            return to_arrow_ipc(data)
+        if format == "records":
+            records = records_from_data(data)
+            if records is None:
+                raise TypeError(
+                    "Record transport requires a list of records or a supported "
+                    "table with record conversion."
+                )
+            return cast(list[Any], json_safe(records))
+        raise ValueError(f"Unsupported dataset format {format!r}.")

--- a/src/genome_spy/chart.py
+++ b/src/genome_spy/chart.py
@@ -487,6 +487,12 @@ class TopLevelSpec(TopLevelMergeMixin, EncodingMethodMixin, TransformMethodMixin
 
         return prepare_render(self)
 
+    def _prepare_widget(self) -> Any:
+        """Prepare this chart for live named-dataset widget updates."""
+        from genome_spy._render import prepare_widget
+
+        return prepare_widget(self)
+
     @property
     def spec(self) -> JsonSpec:
         """Return the rendered GenomeSpy specification with JSON display."""

--- a/src/genome_spy/schema/__init__.py
+++ b/src/genome_spy/schema/__init__.py
@@ -69,6 +69,7 @@ from genome_spy.schema.core import (
     DataFormat,
     DataSource,
     DirectionDef,
+    Displace1DParams,
     DomEventType,
     DomainValue,
     DomainValueArray,
@@ -158,6 +159,8 @@ from genome_spy.schema.core import (
     NumericMarkPropDef,
     NumericStopDef,
     NumericValueDef,
+    OffsetChannel,
+    OffsetDef,
     OtherDataFormat,
     OverhangConfig,
     PackLegendLabelsParams,
@@ -275,6 +278,7 @@ from genome_spy.schema.core import (
     ViewConfig,
     ViewOpacityDef,
     ViewSpec,
+    WigDataFormat,
     WindowOnlyOp,
     WindowOp,
     WindowParams,
@@ -299,6 +303,7 @@ from genome_spy.schema._typing import (
     LegendTitleOrient_T,
     MarkType_T,
     NumericDomain_T,
+    OffsetChannel_T,
     ParseValue_T,
     PrimaryPositionalChannel_T,
     ResolutionBehavior_T,
@@ -377,7 +382,7 @@ from genome_spy.schema._kwds import (
     ScalesKwds,
 )
 
-SCHEMA_VERSION = "0.82.0"
+SCHEMA_VERSION = "0.83.1"
 
 __all__ = [
     "GenomeSpySchema",
@@ -448,6 +453,7 @@ __all__ = [
     "DataFormat",
     "DataSource",
     "DirectionDef",
+    "Displace1DParams",
     "DomEventType",
     "DomainValue",
     "DomainValueArray",
@@ -537,6 +543,8 @@ __all__ = [
     "NumericMarkPropDef",
     "NumericStopDef",
     "NumericValueDef",
+    "OffsetChannel",
+    "OffsetDef",
     "OtherDataFormat",
     "OverhangConfig",
     "PackLegendLabelsParams",
@@ -654,6 +662,7 @@ __all__ = [
     "ViewConfig",
     "ViewOpacityDef",
     "ViewSpec",
+    "WigDataFormat",
     "WindowOnlyOp",
     "WindowOp",
     "WindowParams",
@@ -676,6 +685,7 @@ __all__ = [
     "LegendTitleOrient_T",
     "MarkType_T",
     "NumericDomain_T",
+    "OffsetChannel_T",
     "ParseValue_T",
     "PrimaryPositionalChannel_T",
     "ResolutionBehavior_T",

--- a/src/genome_spy/schema/_kwds.py
+++ b/src/genome_spy/schema/_kwds.py
@@ -111,6 +111,7 @@ class AxisKwds(TypedDict, total=False):
     domainDash: Sequence[float]
     domainDashOffset: float
     domainWidth: float
+    extraValues: Sequence[float]
     format: str
     grid: bool
     gridCap: Literal["butt", "round", "square"]
@@ -190,6 +191,7 @@ class AxisConfigKwds(TypedDict, total=False):
     domainDash: Sequence[float]
     domainDashOffset: float
     domainWidth: float
+    extraValues: Sequence[float]
     format: str
     grid: bool
     gridCap: Literal["butt", "round", "square"]
@@ -423,6 +425,15 @@ class EncodingKwds(TypedDict, total=False):
     uniqueId: FieldDefWithoutScale | dict[str, Any]
     x: dict[str, Any] | None
     x2: Position2Def | dict[str, Any] | None
+    xOffset: (
+        FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+    )
     y: (
         PositionFieldDef
         | dict[str, Any]
@@ -433,6 +444,15 @@ class EncodingKwds(TypedDict, total=False):
         | None
     )
     y2: Position2Def | dict[str, Any] | None
+    yOffset: (
+        FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+    )
 
 
 class EventConfigKwds(TypedDict, total=False):
@@ -474,6 +494,7 @@ class GenomeAxisKwds(TypedDict, total=False):
     domainDash: Sequence[float]
     domainDashOffset: float
     domainWidth: float
+    extraValues: Sequence[float]
     format: str
     grid: bool
     gridCap: Literal["butt", "round", "square"]
@@ -659,10 +680,12 @@ class LinkConfigKwds(TypedDict, total=False):
     tooltip: HandledTooltip | HandledTooltipKwds | None | Literal[False]
     x: float | ExprRef | dict[str, Any]
     x2: float | ExprRef | dict[str, Any]
-    xOffset: float
+    x2Offset: float | ExprRef | dict[str, Any]
+    xOffset: float | ExprRef | dict[str, Any]
     y: float | ExprRef | dict[str, Any]
     y2: float | ExprRef | dict[str, Any]
-    yOffset: float
+    y2Offset: float | ExprRef | dict[str, Any]
+    yOffset: float | ExprRef | dict[str, Any]
 
 
 class MarkConfigKwds(TypedDict, total=False):
@@ -678,9 +701,11 @@ class MarkConfigKwds(TypedDict, total=False):
     style: str | Sequence[str]
     tooltip: HandledTooltip | HandledTooltipKwds | None | Literal[False]
     x: float | ExprRef | dict[str, Any]
-    xOffset: float
+    x2Offset: float | ExprRef | dict[str, Any]
+    xOffset: float | ExprRef | dict[str, Any]
     y: float | ExprRef | dict[str, Any]
-    yOffset: float
+    y2Offset: float | ExprRef | dict[str, Any]
+    yOffset: float | ExprRef | dict[str, Any]
 
 
 class PaddingsKwds(TypedDict, total=False):
@@ -758,9 +783,11 @@ class PointConfigKwds(TypedDict, total=False):
     style: str | Sequence[str]
     tooltip: HandledTooltip | HandledTooltipKwds | None | Literal[False]
     x: float | ExprRef | dict[str, Any]
-    xOffset: float
+    x2Offset: float | ExprRef | dict[str, Any]
+    xOffset: float | ExprRef | dict[str, Any]
     y: float | ExprRef | dict[str, Any]
-    yOffset: float
+    y2Offset: float | ExprRef | dict[str, Any]
+    yOffset: float | ExprRef | dict[str, Any]
 
 
 class RangeConfigKwds(TypedDict, total=False):
@@ -821,10 +848,12 @@ class RectConfigKwds(TypedDict, total=False):
     tooltip: HandledTooltip | HandledTooltipKwds | None | Literal[False]
     x: float | ExprRef | dict[str, Any]
     x2: float | ExprRef | dict[str, Any]
-    xOffset: float
+    x2Offset: float | ExprRef | dict[str, Any]
+    xOffset: float | ExprRef | dict[str, Any]
     y: float | ExprRef | dict[str, Any]
     y2: float | ExprRef | dict[str, Any]
-    yOffset: float
+    y2Offset: float | ExprRef | dict[str, Any]
+    yOffset: float | ExprRef | dict[str, Any]
 
 
 class RuleConfigKwds(TypedDict, total=False):
@@ -852,10 +881,12 @@ class RuleConfigKwds(TypedDict, total=False):
     tooltip: HandledTooltip | HandledTooltipKwds | None | Literal[False]
     x: float | ExprRef | dict[str, Any]
     x2: float | ExprRef | dict[str, Any]
-    xOffset: float
+    x2Offset: float | ExprRef | dict[str, Any]
+    xOffset: float | ExprRef | dict[str, Any]
     y: float | ExprRef | dict[str, Any]
     y2: float | ExprRef | dict[str, Any]
-    yOffset: float
+    y2Offset: float | ExprRef | dict[str, Any]
+    yOffset: float | ExprRef | dict[str, Any]
 
 
 class RulerConfigKwds(TypedDict, total=False):
@@ -1025,10 +1056,12 @@ class SeparatorPropsKwds(TypedDict, total=False):
     type: Literal["rule"]
     x: float | ExprRef | dict[str, Any]
     x2: float | ExprRef | dict[str, Any]
-    xOffset: float
+    x2Offset: float | ExprRef | dict[str, Any]
+    xOffset: float | ExprRef | dict[str, Any]
     y: float | ExprRef | dict[str, Any]
     y2: float | ExprRef | dict[str, Any]
-    yOffset: float
+    y2Offset: float | ExprRef | dict[str, Any]
+    yOffset: float | ExprRef | dict[str, Any]
     zindex: float
 
 
@@ -1086,10 +1119,12 @@ class TextConfigKwds(TypedDict, total=False):
     viewportEdgeFadeWidthTop: float
     x: float | ExprRef | dict[str, Any]
     x2: float | ExprRef | dict[str, Any]
-    xOffset: float
+    x2Offset: float | ExprRef | dict[str, Any]
+    xOffset: float | ExprRef | dict[str, Any]
     y: float | ExprRef | dict[str, Any]
     y2: float | ExprRef | dict[str, Any]
-    yOffset: float
+    y2Offset: float | ExprRef | dict[str, Any]
+    yOffset: float | ExprRef | dict[str, Any]
 
 
 class TitleKwds(TypedDict, total=False):
@@ -1224,6 +1259,8 @@ class LegendsKwds(TypedDict, total=False):
     stroke: Legend | LegendKwds
     strokeOpacity: Legend | LegendKwds
     strokeWidth: Legend | LegendKwds
+    xOffset: Legend | LegendKwds
+    yOffset: Legend | LegendKwds
 
 
 class AxisResolveKwds(TypedDict, total=False):
@@ -1253,8 +1290,10 @@ class AxisResolveKwds(TypedDict, total=False):
     uniqueId: ResolutionBehavior_T
     x: ResolutionBehavior_T
     x2: ResolutionBehavior_T
+    xOffset: ResolutionBehavior_T
     y: ResolutionBehavior_T
     y2: ResolutionBehavior_T
+    yOffset: ResolutionBehavior_T
 
 
 class LegendResolveKwds(TypedDict, total=False):
@@ -1284,8 +1323,10 @@ class LegendResolveKwds(TypedDict, total=False):
     uniqueId: ResolutionBehavior_T
     x: ResolutionBehavior_T
     x2: ResolutionBehavior_T
+    xOffset: ResolutionBehavior_T
     y: ResolutionBehavior_T
     y2: ResolutionBehavior_T
+    yOffset: ResolutionBehavior_T
 
 
 class ScaleResolveKwds(TypedDict, total=False):
@@ -1315,8 +1356,10 @@ class ScaleResolveKwds(TypedDict, total=False):
     uniqueId: ResolutionBehavior_T
     x: ResolutionBehavior_T
     x2: ResolutionBehavior_T
+    xOffset: ResolutionBehavior_T
     y: ResolutionBehavior_T
     y2: ResolutionBehavior_T
+    yOffset: ResolutionBehavior_T
 
 
 class ResolveKwds(TypedDict, total=False):
@@ -1345,8 +1388,10 @@ class ScalesKwds(TypedDict, total=False):
     strokeWidth: Scale | ScaleKwds
     x: Scale | ScaleKwds
     x2: Scale | ScaleKwds
+    xOffset: Scale | ScaleKwds
     y: Scale | ScaleKwds
     y2: Scale | ScaleKwds
+    yOffset: Scale | ScaleKwds
 
 
 __all__ = [

--- a/src/genome_spy/schema/_typing.py
+++ b/src/genome_spy/schema/_typing.py
@@ -55,6 +55,7 @@ MarkType_T: TypeAlias = Literal[
     "rect", "point", "rule", "tick", "text", "link", "arrow"
 ]
 NumericDomain_T: TypeAlias = Sequence[float]
+OffsetChannel_T: TypeAlias = Literal["xOffset", "yOffset"]
 ParseValue_T: TypeAlias = str | None
 PrimaryPositionalChannel_T: TypeAlias = Literal["x", "y"]
 ResolutionBehavior_T: TypeAlias = Literal["independent", "shared", "excluded", "forced"]
@@ -92,6 +93,7 @@ PositionalChannel_T: TypeAlias = (
 )
 ChannelWithScale_T: TypeAlias = (
     PositionalChannel_T
+    | OffsetChannel_T
     | Literal["color"]
     | Literal["fill"]
     | Literal["stroke"]
@@ -150,6 +152,7 @@ __all__ = [
     "LegendTitleOrient_T",
     "MarkType_T",
     "NumericDomain_T",
+    "OffsetChannel_T",
     "ParseValue_T",
     "PrimaryPositionalChannel_T",
     "ResolutionBehavior_T",

--- a/src/genome_spy/schema/capabilities.json
+++ b/src/genome_spy/schema/capabilities.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "0.82.0",
+  "schema_version": "0.83.1",
   "definitions": [
     "AggregateOp",
     "AggregateParams",
@@ -65,6 +65,7 @@
     "DataFormat",
     "DataSource",
     "DirectionDef",
+    "Displace1DParams",
     "DomEventType",
     "DomainValue",
     "DomainValueArray",
@@ -154,6 +155,8 @@
     "NumericMarkPropDef",
     "NumericStopDef",
     "NumericValueDef",
+    "OffsetChannel",
+    "OffsetDef",
     "OtherDataFormat",
     "OverhangConfig",
     "PackLegendLabelsParams",
@@ -271,6 +274,7 @@
     "ViewConfig",
     "ViewOpacityDef",
     "ViewSpec",
+    "WigDataFormat",
     "WindowOnlyOp",
     "WindowOp",
     "WindowParams",
@@ -309,8 +313,10 @@
     "uniqueId",
     "x",
     "x2",
+    "xOffset",
     "y",
-    "y2"
+    "y2",
+    "yOffset"
   ],
   "transforms": [
     {
@@ -342,6 +348,11 @@
       "schema": "CrossParams",
       "type": "cross",
       "method": "transform_cross"
+    },
+    {
+      "schema": "Displace1DParams",
+      "type": "displace1d",
+      "method": "transform_displace1d"
     },
     {
       "schema": "FlattenDelimitedParams",

--- a/src/genome_spy/schema/channels.py
+++ b/src/genome_spy/schema/channels.py
@@ -366,7 +366,7 @@ class Angle(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -723,7 +723,7 @@ class Color(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -977,7 +977,7 @@ class Direction(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -1334,7 +1334,7 @@ class Dx(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -1691,7 +1691,7 @@ class Dy(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -2123,7 +2123,7 @@ class Fill(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -2480,7 +2480,7 @@ class FillOpacity(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -2912,7 +2912,7 @@ class Opacity(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -3504,7 +3504,7 @@ class Shape(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -3861,7 +3861,7 @@ class Size(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -4218,7 +4218,7 @@ class Stroke(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -4575,7 +4575,7 @@ class StrokeOpacity(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -4932,7 +4932,7 @@ class StrokeWidth(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -5196,7 +5196,7 @@ class Text(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -5460,7 +5460,7 @@ class Tooltip(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -5801,6 +5801,7 @@ class X(Channel):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -5879,6 +5880,7 @@ class X(Channel):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -5955,6 +5957,7 @@ class X(Channel):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -6069,7 +6072,7 @@ class X(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -6325,6 +6328,7 @@ class X2(Channel):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -6403,6 +6407,7 @@ class X2(Channel):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -6479,6 +6484,7 @@ class X2(Channel):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -6593,7 +6599,364 @@ class X2(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
+            padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
+            paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
+            paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
+            range (Sequence[float | str | ExprRef | dict[str, Any]] | str): The range of the scale. One of: - A string indicating a pre-defined named scale range (e.g., example, ``"symbol"``, or ``"diverging"``). - For continuous scales, two-element array indicating minimum and maximum values, or an array with more than two entries for specifying a piecewise scale. Array elements may also be expression references. - For discrete and discretizing scales, an array of desired output values. Array elements may also be expression references. __Notes:__ 1) For color scales you can also specify a color ``scheme`` instead of ``range``. 2) Any directly specified ``range`` for ``x`` and ``y`` channels will be ignored. Range can be customized via the view's corresponding size (``width`` and ``height``).
+            reverse (bool): If true, reverses the order of the scale range. __Default value:__ ``false``.
+            round (bool): If ``true``, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid. __Default value:__ ``false``.
+            scheme (str | SchemeParams | SchemeParamsKwds): A string indicating a color scheme name (e.g., ``"category10"`` or ``"blues"``) or a scheme parameter object. Discrete color schemes may be used with discrete or discretizing scales. Continuous color schemes are intended for use with color scales. For the full list of supported schemes, please refer to the Vega Scheme reference.
+            type (ScaleType_T): The type of scale. Vega-Lite supports the following categories of scale types: 1) **Continuous Scales** -- mapping continuous domains to continuous output ranges (``"linear"``, ``"pow"``, ``"sqrt"``, ``"symlog"``, ``"log"``, ``"time"``, ``"utc"``. 2) **Discrete Scales** -- mapping discrete domains to discrete (``"ordinal"``) or continuous (``"band"`` and ``"point"``) output ranges. 3) **Discretizing Scales** -- mapping continuous domains to discrete output ranges ``"bin-ordinal"``, ``"quantile"``, ``"quantize"`` and ``"threshold"``. __Default value:__ please see the scale type table.
+            zero (bool): If ``true``, ensures that a zero baseline value is included in the scale domain. __Default value:__ ``true`` for x and y channels if the quantitative field is not binned and no custom ``domain`` is provided; ``false`` otherwise. __Note:__ Log, time, and utc scales do not support ``zero``.
+            zoom (bool | ZoomParams | ZoomParamsKwds): If ``true`` and the scale is used on a positional channel, it can bee zoomed and translated interactively.
+        """
+        defined = {
+            "align": align,
+            "assembly": assembly,
+            "base": base,
+            "bins": bins,
+            "clamp": clamp,
+            "constant": constant,
+            "domain": domain,
+            "domainMax": domainMax,
+            "domainMid": domainMid,
+            "domainMin": domainMin,
+            "domainTransition": domainTransition,
+            "exponent": exponent,
+            "interpolate": interpolate,
+            "name": name,
+            "nice": nice,
+            "numberingOffset": numberingOffset,
+            "padding": padding,
+            "paddingInner": paddingInner,
+            "paddingOuter": paddingOuter,
+            "range": range,
+            "reverse": reverse,
+            "round": round,
+            "scheme": scheme,
+            "type": type,
+            "zero": zero,
+            "zoom": zoom,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_nested("scale", value, **defined)
+
+
+class XOffset(Channel):
+    """Generated wrapper for the ``xOffset`` encoding channel."""
+
+    def __init__(
+        self,
+        value: Channel | SchemaBase | str | dict[str, Any],
+        /,
+        *,
+        band: float | UndefinedType = _MISSING,
+        condition: ConditionalParameterMarkPropFieldDefType
+        | dict[str, Any]
+        | ConditionalParameterScaleDatumDef
+        | ConditionalParameterMarkPropExprDefType
+        | ConditionalParameterValueDefNumberExprRef
+        | Sequence[ConditionalParameterValueDefNumberExprRef | dict[str, Any]]
+        | UndefinedType = _MISSING,
+        datum: Scalar_T | ExprRef | dict[str, Any] | UndefinedType = _MISSING,
+        description: str | UndefinedType = _MISSING,
+        domainInert: bool | UndefinedType = _MISSING,
+        expr: str | UndefinedType = _MISSING,
+        field: str | UndefinedType = _MISSING,
+        format: str | UndefinedType = _MISSING,
+        resolutionChannel: ChannelWithScale_T | UndefinedType = _MISSING,
+        title: str | None | UndefinedType = _MISSING,
+        type: Type_T | UndefinedType = _MISSING,
+        legend: Legend | LegendKwds | None | UndefinedType = _MISSING,
+        scale: Scale | ScaleKwds | None | UndefinedType = _MISSING,
+    ) -> None:
+        """Create a ``xOffset`` encoding channel.
+
+        Args:
+            band (float): Relative position on band scale. For example, the marks will be positioned at the beginning of the band if set to ``0``, and at the middle of the band if set to ``0.5``.
+            condition (ConditionalParameterMarkPropFieldDefType | dict[str, Any] | ConditionalParameterScaleDatumDef | ConditionalParameterMarkPropExprDefType | ConditionalParameterValueDefNumberExprRef | Sequence[ConditionalParameterValueDefNumberExprRef | dict[str, Any]]): A field definition or one or more value definition(s) with a parameter predicate.
+            datum (Scalar_T | ExprRef | dict[str, Any]): A constant value in data domain.
+            description (str): A description of the encoded expression. Can be used for documentation and to explain the meaning of the channel mapping.
+            domainInert (bool): Whether the field or evaluated expr should be excluded from the scale's domain. Prefer the view-level ``domainInert`` when an entire subtree should be excluded. **Default value:** ``false``
+            expr (str): An expression. Properties of the data can be accessed through the ``datum`` object.
+            field (str): __Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the ``repeat`` operator. __See also:__ ``field`` documentation. __Notes:__ 1) Dots (``.``) and brackets (``[`` and ``]``) can be used to access nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"``). If field names contain dots or brackets but are not nested, you can use ``\\`` to escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"``). See more details about escaping in the field documentation. 2) ``field`` is not required if ``aggregate`` is ``count``.
+            format (str): When used with the default ``"number"`` format type, the text formatting pattern for labels of guides (axes, legends, headers) and text marks. - If the format type is ``"number"`` (e.g., for quantitative fields), this is D3's number format pattern. See the format documentation for more examples.
+            legend (Legend | LegendKwds | None): Legend properties for the encoding channel. If ``null``, the legend for the channel is removed. If an object is provided, a legend is created even when legends are disabled by default in the config. __Default value:__ If undefined, configured legend defaults are applied.
+            resolutionChannel (ChannelWithScale_T): An alternative channel for scale resolution. This is mainly for internal use and allows using ``color`` channel to resolve ``fill`` and ``stroke`` channels under certain circumstances.
+            scale (Scale | ScaleKwds | None): An object defining properties of the channel's scale, which is the function that transforms values in the data domain (numbers, dates, strings, etc) to visual values (pixels, colors, sizes) of the encoding channels. If ``null``, the scale will be disabled and the data value will be directly encoded. __Default value:__ If undefined, default scale properties are applied. __See also:__ ``scale`` documentation.
+            title (str | None): A title for the field. If ``null``, the title will be removed.
+            type (Type_T): Schema-defined ``type`` property.
+            value (float | ExprRef | dict[str, Any]): A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"``, values between ``0`` to ``1`` for opacity).
+        """
+        properties = {
+            "band": band,
+            "condition": condition,
+            "datum": datum,
+            "description": description,
+            "domainInert": domainInert,
+            "expr": expr,
+            "field": field,
+            "format": format,
+            "resolutionChannel": resolutionChannel,
+            "title": title,
+            "type": type,
+            "legend": legend,
+            "scale": scale,
+        }
+        defined = {
+            key: item for key, item in properties.items() if item is not _MISSING
+        }
+        wrapped = channel(value, encoding_name="xOffset", **defined)
+        super().__init__(wrapped.definition, encoding_name="xOffset")
+
+    def band(
+        self,
+        value: float,
+    ) -> XOffset:
+        """Return a channel with ``band`` updated."""
+        return self._with_property("band", value)
+
+    def condition(
+        self,
+        value: ConditionalParameterMarkPropFieldDefType
+        | dict[str, Any]
+        | ConditionalParameterScaleDatumDef
+        | ConditionalParameterMarkPropExprDefType
+        | ConditionalParameterValueDefNumberExprRef
+        | Sequence[ConditionalParameterValueDefNumberExprRef | dict[str, Any]],
+    ) -> XOffset:
+        """Return a channel with ``condition`` updated."""
+        return self._with_property("condition", value)
+
+    def datum(
+        self,
+        value: Scalar_T | ExprRef | dict[str, Any],
+    ) -> XOffset:
+        """Return a channel with ``datum`` updated."""
+        return self._with_property("datum", value)
+
+    def description(
+        self,
+        value: str,
+    ) -> XOffset:
+        """Return a channel with ``description`` updated."""
+        return self._with_property("description", value)
+
+    def domainInert(
+        self,
+        value: bool,
+    ) -> XOffset:
+        """Return a channel with ``domainInert`` updated."""
+        return self._with_property("domainInert", value)
+
+    def expr(
+        self,
+        value: str,
+    ) -> XOffset:
+        """Return a channel with ``expr`` updated."""
+        return self._with_property("expr", value)
+
+    def field(
+        self,
+        value: str,
+    ) -> XOffset:
+        """Return a channel with ``field`` updated."""
+        return self._with_property("field", value)
+
+    def format(
+        self,
+        value: str,
+    ) -> XOffset:
+        """Return a channel with ``format`` updated."""
+        return self._with_property("format", value)
+
+    def resolutionChannel(
+        self,
+        value: ChannelWithScale_T,
+    ) -> XOffset:
+        """Return a channel with ``resolutionChannel`` updated."""
+        return self._with_property("resolutionChannel", value)
+
+    def title(
+        self,
+        value: str | None,
+    ) -> XOffset:
+        """Return a channel with ``title`` updated."""
+        return self._with_property("title", value)
+
+    def type(
+        self,
+        value: Type_T,
+    ) -> XOffset:
+        """Return a channel with ``type`` updated."""
+        return self._with_property("type", value)
+
+    def value(
+        self,
+        value: float | ExprRef | dict[str, Any],
+    ) -> XOffset:
+        """Return a channel with ``value`` updated."""
+        return self._with_property("value", value)
+
+    def sort(
+        self,
+        value: CompareParams
+        | CompareParamsKwds
+        | str
+        | list[str]
+        | None
+        | object = _MISSING,
+        /,
+        *,
+        field: Sequence[Field_T] | Field_T | UndefinedType = Undefined,
+        order: Sequence[SortOrder_T] | SortOrder_T | UndefinedType = Undefined,
+    ) -> XOffset:
+        """Return a channel with a ``sort`` configuration."""
+        properties = {
+            "field": field,
+            "order": order,
+        }
+        defined = {
+            key: item for key, item in properties.items() if item is not Undefined
+        }
+        return self._with_sort(value, defined)
+
+    def legend(
+        self,
+        value: Legend | LegendKwds | None | object = Undefined,
+        /,
+        *,
+        backgroundFill: str | UndefinedType = Undefined,
+        backgroundFillOpacity: float | UndefinedType = Undefined,
+        backgroundStroke: str | UndefinedType = Undefined,
+        backgroundStrokeOpacity: float | UndefinedType = Undefined,
+        backgroundStrokeWidth: float | UndefinedType = Undefined,
+        columns: float | UndefinedType = Undefined,
+        direction: LegendDirection_T | UndefinedType = Undefined,
+        labelLimit: float | UndefinedType = Undefined,
+        offset: float | UndefinedType = Undefined,
+        orient: LegendOrient_T
+        | core.ExprRef
+        | dict[str, Any]
+        | UndefinedType = Undefined,
+        padding: float | UndefinedType = Undefined,
+        style: str | Sequence[str] | None | UndefinedType = Undefined,
+        symbolSize: float | UndefinedType = Undefined,
+        symbolType: str | UndefinedType = Undefined,
+        title: str | None | UndefinedType = Undefined,
+        titleOrient: LegendTitleOrient_T | UndefinedType = Undefined,
+        values: Sequence[str | float | bool] | UndefinedType = Undefined,
+    ) -> XOffset:
+        """Return a channel with a ``Legend`` legend.
+
+        Args:
+            backgroundFill (str): Fill color of the legend background.
+            backgroundFillOpacity (float): Opacity of the legend background fill.
+            backgroundStroke (str): Stroke color of the legend background.
+            backgroundStrokeOpacity (float): Opacity of the legend background stroke.
+            backgroundStrokeWidth (float): Stroke width of the legend background border.
+            columns (float): The number of columns in which to arrange symbol legend entries.
+            direction (LegendDirection_T): The direction in which legend entries are laid out.
+            labelLimit (float): Maximum label text width in pixels.
+            offset (float): External gap in pixels between the legend and the plot edge.
+            orient (LegendOrient_T | ExprRef | dict[str, Any]): The plot side or inside corner where the legend is placed. Side legends are placed outside the plot area. Corner legends are placed inside the plot area.
+            padding (float): Internal padding in pixels around the legend content and background.
+            style (str | Sequence[str] | None): Named style reference or references resolved from ``config.style``. If an array is provided, later styles override earlier ones. Set to ``null`` to reset inherited legend styles.
+            symbolSize (float): Symbol size in pixels squared.
+            symbolType (str): Symbol shape.
+            title (str | None): Title text for the legend. If ``null``, the title is removed.
+            titleOrient (LegendTitleOrient_T): The side of the legend on which to place the title.
+            values (Sequence[str | float | bool]): Explicit values to show in the legend. For discrete symbol legends, the values define an ordered subset of entries. For quantitative symbol and gradient legends, the values define the shown representative values or ticks.
+        """
+        defined = {
+            "backgroundFill": backgroundFill,
+            "backgroundFillOpacity": backgroundFillOpacity,
+            "backgroundStroke": backgroundStroke,
+            "backgroundStrokeOpacity": backgroundStrokeOpacity,
+            "backgroundStrokeWidth": backgroundStrokeWidth,
+            "columns": columns,
+            "direction": direction,
+            "labelLimit": labelLimit,
+            "offset": offset,
+            "orient": orient,
+            "padding": padding,
+            "style": style,
+            "symbolSize": symbolSize,
+            "symbolType": symbolType,
+            "title": title,
+            "titleOrient": titleOrient,
+            "values": values,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_nested("legend", value, **defined)
+
+    def scale(
+        self,
+        value: Scale | ScaleKwds | None | object = Undefined,
+        /,
+        *,
+        align: float | UndefinedType = Undefined,
+        assembly: str
+        | core.UrlGenomeDefinition
+        | dict[str, Any]
+        | core.InlineGenomeDefinition
+        | UndefinedType = Undefined,
+        base: float | UndefinedType = Undefined,
+        bins: Sequence[float] | UndefinedType = Undefined,
+        clamp: bool | UndefinedType = Undefined,
+        constant: float | UndefinedType = Undefined,
+        domain: ScalarDomain_T
+        | Sequence[core.ChromosomalLocus | dict[str, Any]]
+        | core.SelectionDomainRef
+        | dict[str, Any]
+        | core.ExprRef
+        | Sequence[float | str | bool | core.ExprRef | dict[str, Any]]
+        | UndefinedType = Undefined,
+        domainMax: float | UndefinedType = Undefined,
+        domainMid: float | UndefinedType = Undefined,
+        domainMin: float | UndefinedType = Undefined,
+        domainTransition: bool | dict[str, Any] | UndefinedType = Undefined,
+        exponent: float | UndefinedType = Undefined,
+        interpolate: ScaleInterpolate_T
+        | core.ScaleInterpolateParams
+        | ScaleInterpolateParamsKwds
+        | UndefinedType = Undefined,
+        name: str | UndefinedType = Undefined,
+        nice: bool | float | dict[str, Any] | UndefinedType = Undefined,
+        numberingOffset: float | UndefinedType = Undefined,
+        padding: float | UndefinedType = Undefined,
+        paddingInner: float | UndefinedType = Undefined,
+        paddingOuter: float | UndefinedType = Undefined,
+        range: Sequence[float | str | core.ExprRef | dict[str, Any]]
+        | str
+        | UndefinedType = Undefined,
+        reverse: bool | UndefinedType = Undefined,
+        round: bool | UndefinedType = Undefined,
+        scheme: str | core.SchemeParams | SchemeParamsKwds | UndefinedType = Undefined,
+        type: ScaleType_T | UndefinedType = Undefined,
+        zero: bool | UndefinedType = Undefined,
+        zoom: bool | core.ZoomParams | ZoomParamsKwds | UndefinedType = Undefined,
+    ) -> XOffset:
+        """Return a channel with a ``Scale`` scale.
+
+        Args:
+            align (float): The alignment of the steps within the scale range. This value must lie in the range ``[0,1]``. A value of ``0.5`` indicates that the steps should be centered within the range. A value of ``0`` or ``1`` may be used to shift the bands to one side, say to position them adjacent to an axis. __Default value:__ ``0.5``
+            assembly (str | UrlGenomeDefinition | dict[str, Any] | InlineGenomeDefinition): Genome assembly definition for locus scales. This can be: - A string reference to a named assembly (built-in or root-configured). - An inline anonymous assembly that defines either ``contigs`` or ``url``. If undefined, the default genome from the genome store is used.
+            base (float): The logarithm base of the ``log`` scale (default ``10``).
+            bins (Sequence[float]): An array of bin boundaries over the scale domain. If provided, axes and legends will use the bin boundaries to inform the choice of tick marks and text labels.
+            clamp (bool): If ``true``, values that exceed the data domain are clamped to either the minimum or maximum range value __Default value:__ derived from the scale config's ``clamp`` (``true`` by default).
+            constant (float): A constant determining the slope of the symlog function around zero. Only used for ``symlog`` scales. __Default value:__ ``1``
+            domain (ScalarDomain_T | Sequence[ChromosomalLocus | dict[str, Any]] | SelectionDomainRef | dict[str, Any] | ExprRef | Sequence[float | str | bool | ExprRef | dict[str, Any]]): Customized domain values. For quantitative fields, ``domain`` can take the form of a two-element array with minimum and maximum values. Piecewise scales can be created by providing a ``domain`` with more than two entries. For temporal fields, ``domain`` can be a two-element array minimum and maximum values, in the form of either timestamps or the DateTime definition objects. For ordinal and nominal fields, ``domain`` can be an array that lists valid input values. The domain can also be defined by an expression reference that evaluates to the domain array. Array elements may also be expression references.
+            domainMax (float): Sets the maximum value in the scale domain, overriding the ``domain`` property. This property is only intended for use with scales having continuous domains.
+            domainMid (float): Inserts a single mid-point value into a two-element domain. The mid-point value must lie between the domain minimum and maximum values. This property can be useful for setting a midpoint for diverging color scales. The domainMid property is only intended for use with scales supporting continuous, piecewise domains.
+            domainMin (float): Sets the minimum value in the scale domain, overriding the domain property. This property is only intended for use with scales having continuous domains.
+            domainTransition (bool | dict[str, Any]): Controls whether domain updates are applied immediately or with a smooth transition. Set this to ``false`` to apply domain updates immediately. The default is ``true``, except for domains that include ``ExprRef``s, which default to ``false`` unless overridden. __Default value:__ ``true``, except ``false`` for ``ExprRef``-driven domains.
+            exponent (float): The exponent of the ``pow`` scale.
+            interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
+            name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
+            nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -6849,6 +7212,7 @@ class Y(Channel):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -6927,6 +7291,7 @@ class Y(Channel):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -7003,6 +7368,7 @@ class Y(Channel):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -7117,7 +7483,7 @@ class Y(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -7373,6 +7739,7 @@ class Y2(Channel):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -7451,6 +7818,7 @@ class Y2(Channel):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -7527,6 +7895,7 @@ class Y2(Channel):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -7641,7 +8010,364 @@ class Y2(Channel):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
+            padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
+            paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
+            paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
+            range (Sequence[float | str | ExprRef | dict[str, Any]] | str): The range of the scale. One of: - A string indicating a pre-defined named scale range (e.g., example, ``"symbol"``, or ``"diverging"``). - For continuous scales, two-element array indicating minimum and maximum values, or an array with more than two entries for specifying a piecewise scale. Array elements may also be expression references. - For discrete and discretizing scales, an array of desired output values. Array elements may also be expression references. __Notes:__ 1) For color scales you can also specify a color ``scheme`` instead of ``range``. 2) Any directly specified ``range`` for ``x`` and ``y`` channels will be ignored. Range can be customized via the view's corresponding size (``width`` and ``height``).
+            reverse (bool): If true, reverses the order of the scale range. __Default value:__ ``false``.
+            round (bool): If ``true``, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid. __Default value:__ ``false``.
+            scheme (str | SchemeParams | SchemeParamsKwds): A string indicating a color scheme name (e.g., ``"category10"`` or ``"blues"``) or a scheme parameter object. Discrete color schemes may be used with discrete or discretizing scales. Continuous color schemes are intended for use with color scales. For the full list of supported schemes, please refer to the Vega Scheme reference.
+            type (ScaleType_T): The type of scale. Vega-Lite supports the following categories of scale types: 1) **Continuous Scales** -- mapping continuous domains to continuous output ranges (``"linear"``, ``"pow"``, ``"sqrt"``, ``"symlog"``, ``"log"``, ``"time"``, ``"utc"``. 2) **Discrete Scales** -- mapping discrete domains to discrete (``"ordinal"``) or continuous (``"band"`` and ``"point"``) output ranges. 3) **Discretizing Scales** -- mapping continuous domains to discrete output ranges ``"bin-ordinal"``, ``"quantile"``, ``"quantize"`` and ``"threshold"``. __Default value:__ please see the scale type table.
+            zero (bool): If ``true``, ensures that a zero baseline value is included in the scale domain. __Default value:__ ``true`` for x and y channels if the quantitative field is not binned and no custom ``domain`` is provided; ``false`` otherwise. __Note:__ Log, time, and utc scales do not support ``zero``.
+            zoom (bool | ZoomParams | ZoomParamsKwds): If ``true`` and the scale is used on a positional channel, it can bee zoomed and translated interactively.
+        """
+        defined = {
+            "align": align,
+            "assembly": assembly,
+            "base": base,
+            "bins": bins,
+            "clamp": clamp,
+            "constant": constant,
+            "domain": domain,
+            "domainMax": domainMax,
+            "domainMid": domainMid,
+            "domainMin": domainMin,
+            "domainTransition": domainTransition,
+            "exponent": exponent,
+            "interpolate": interpolate,
+            "name": name,
+            "nice": nice,
+            "numberingOffset": numberingOffset,
+            "padding": padding,
+            "paddingInner": paddingInner,
+            "paddingOuter": paddingOuter,
+            "range": range,
+            "reverse": reverse,
+            "round": round,
+            "scheme": scheme,
+            "type": type,
+            "zero": zero,
+            "zoom": zoom,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_nested("scale", value, **defined)
+
+
+class YOffset(Channel):
+    """Generated wrapper for the ``yOffset`` encoding channel."""
+
+    def __init__(
+        self,
+        value: Channel | SchemaBase | str | dict[str, Any],
+        /,
+        *,
+        band: float | UndefinedType = _MISSING,
+        condition: ConditionalParameterMarkPropFieldDefType
+        | dict[str, Any]
+        | ConditionalParameterScaleDatumDef
+        | ConditionalParameterMarkPropExprDefType
+        | ConditionalParameterValueDefNumberExprRef
+        | Sequence[ConditionalParameterValueDefNumberExprRef | dict[str, Any]]
+        | UndefinedType = _MISSING,
+        datum: Scalar_T | ExprRef | dict[str, Any] | UndefinedType = _MISSING,
+        description: str | UndefinedType = _MISSING,
+        domainInert: bool | UndefinedType = _MISSING,
+        expr: str | UndefinedType = _MISSING,
+        field: str | UndefinedType = _MISSING,
+        format: str | UndefinedType = _MISSING,
+        resolutionChannel: ChannelWithScale_T | UndefinedType = _MISSING,
+        title: str | None | UndefinedType = _MISSING,
+        type: Type_T | UndefinedType = _MISSING,
+        legend: Legend | LegendKwds | None | UndefinedType = _MISSING,
+        scale: Scale | ScaleKwds | None | UndefinedType = _MISSING,
+    ) -> None:
+        """Create a ``yOffset`` encoding channel.
+
+        Args:
+            band (float): Relative position on band scale. For example, the marks will be positioned at the beginning of the band if set to ``0``, and at the middle of the band if set to ``0.5``.
+            condition (ConditionalParameterMarkPropFieldDefType | dict[str, Any] | ConditionalParameterScaleDatumDef | ConditionalParameterMarkPropExprDefType | ConditionalParameterValueDefNumberExprRef | Sequence[ConditionalParameterValueDefNumberExprRef | dict[str, Any]]): A field definition or one or more value definition(s) with a parameter predicate.
+            datum (Scalar_T | ExprRef | dict[str, Any]): A constant value in data domain.
+            description (str): A description of the encoded expression. Can be used for documentation and to explain the meaning of the channel mapping.
+            domainInert (bool): Whether the field or evaluated expr should be excluded from the scale's domain. Prefer the view-level ``domainInert`` when an entire subtree should be excluded. **Default value:** ``false``
+            expr (str): An expression. Properties of the data can be accessed through the ``datum`` object.
+            field (str): __Required.__ A string defining the name of the field from which to pull a data value or an object defining iterated values from the ``repeat`` operator. __See also:__ ``field`` documentation. __Notes:__ 1) Dots (``.``) and brackets (``[`` and ``]``) can be used to access nested objects (e.g., ``"field": "foo.bar"`` and ``"field": "foo['bar']"``). If field names contain dots or brackets but are not nested, you can use ``\\`` to escape dots and brackets (e.g., ``"a\\.b"`` and ``"a\\[0\\]"``). See more details about escaping in the field documentation. 2) ``field`` is not required if ``aggregate`` is ``count``.
+            format (str): When used with the default ``"number"`` format type, the text formatting pattern for labels of guides (axes, legends, headers) and text marks. - If the format type is ``"number"`` (e.g., for quantitative fields), this is D3's number format pattern. See the format documentation for more examples.
+            legend (Legend | LegendKwds | None): Legend properties for the encoding channel. If ``null``, the legend for the channel is removed. If an object is provided, a legend is created even when legends are disabled by default in the config. __Default value:__ If undefined, configured legend defaults are applied.
+            resolutionChannel (ChannelWithScale_T): An alternative channel for scale resolution. This is mainly for internal use and allows using ``color`` channel to resolve ``fill`` and ``stroke`` channels under certain circumstances.
+            scale (Scale | ScaleKwds | None): An object defining properties of the channel's scale, which is the function that transforms values in the data domain (numbers, dates, strings, etc) to visual values (pixels, colors, sizes) of the encoding channels. If ``null``, the scale will be disabled and the data value will be directly encoded. __Default value:__ If undefined, default scale properties are applied. __See also:__ ``scale`` documentation.
+            title (str | None): A title for the field. If ``null``, the title will be removed.
+            type (Type_T): Schema-defined ``type`` property.
+            value (float | ExprRef | dict[str, Any]): A constant value in visual domain (e.g., ``"red"`` / ``"#0099ff"``, values between ``0`` to ``1`` for opacity).
+        """
+        properties = {
+            "band": band,
+            "condition": condition,
+            "datum": datum,
+            "description": description,
+            "domainInert": domainInert,
+            "expr": expr,
+            "field": field,
+            "format": format,
+            "resolutionChannel": resolutionChannel,
+            "title": title,
+            "type": type,
+            "legend": legend,
+            "scale": scale,
+        }
+        defined = {
+            key: item for key, item in properties.items() if item is not _MISSING
+        }
+        wrapped = channel(value, encoding_name="yOffset", **defined)
+        super().__init__(wrapped.definition, encoding_name="yOffset")
+
+    def band(
+        self,
+        value: float,
+    ) -> YOffset:
+        """Return a channel with ``band`` updated."""
+        return self._with_property("band", value)
+
+    def condition(
+        self,
+        value: ConditionalParameterMarkPropFieldDefType
+        | dict[str, Any]
+        | ConditionalParameterScaleDatumDef
+        | ConditionalParameterMarkPropExprDefType
+        | ConditionalParameterValueDefNumberExprRef
+        | Sequence[ConditionalParameterValueDefNumberExprRef | dict[str, Any]],
+    ) -> YOffset:
+        """Return a channel with ``condition`` updated."""
+        return self._with_property("condition", value)
+
+    def datum(
+        self,
+        value: Scalar_T | ExprRef | dict[str, Any],
+    ) -> YOffset:
+        """Return a channel with ``datum`` updated."""
+        return self._with_property("datum", value)
+
+    def description(
+        self,
+        value: str,
+    ) -> YOffset:
+        """Return a channel with ``description`` updated."""
+        return self._with_property("description", value)
+
+    def domainInert(
+        self,
+        value: bool,
+    ) -> YOffset:
+        """Return a channel with ``domainInert`` updated."""
+        return self._with_property("domainInert", value)
+
+    def expr(
+        self,
+        value: str,
+    ) -> YOffset:
+        """Return a channel with ``expr`` updated."""
+        return self._with_property("expr", value)
+
+    def field(
+        self,
+        value: str,
+    ) -> YOffset:
+        """Return a channel with ``field`` updated."""
+        return self._with_property("field", value)
+
+    def format(
+        self,
+        value: str,
+    ) -> YOffset:
+        """Return a channel with ``format`` updated."""
+        return self._with_property("format", value)
+
+    def resolutionChannel(
+        self,
+        value: ChannelWithScale_T,
+    ) -> YOffset:
+        """Return a channel with ``resolutionChannel`` updated."""
+        return self._with_property("resolutionChannel", value)
+
+    def title(
+        self,
+        value: str | None,
+    ) -> YOffset:
+        """Return a channel with ``title`` updated."""
+        return self._with_property("title", value)
+
+    def type(
+        self,
+        value: Type_T,
+    ) -> YOffset:
+        """Return a channel with ``type`` updated."""
+        return self._with_property("type", value)
+
+    def value(
+        self,
+        value: float | ExprRef | dict[str, Any],
+    ) -> YOffset:
+        """Return a channel with ``value`` updated."""
+        return self._with_property("value", value)
+
+    def sort(
+        self,
+        value: CompareParams
+        | CompareParamsKwds
+        | str
+        | list[str]
+        | None
+        | object = _MISSING,
+        /,
+        *,
+        field: Sequence[Field_T] | Field_T | UndefinedType = Undefined,
+        order: Sequence[SortOrder_T] | SortOrder_T | UndefinedType = Undefined,
+    ) -> YOffset:
+        """Return a channel with a ``sort`` configuration."""
+        properties = {
+            "field": field,
+            "order": order,
+        }
+        defined = {
+            key: item for key, item in properties.items() if item is not Undefined
+        }
+        return self._with_sort(value, defined)
+
+    def legend(
+        self,
+        value: Legend | LegendKwds | None | object = Undefined,
+        /,
+        *,
+        backgroundFill: str | UndefinedType = Undefined,
+        backgroundFillOpacity: float | UndefinedType = Undefined,
+        backgroundStroke: str | UndefinedType = Undefined,
+        backgroundStrokeOpacity: float | UndefinedType = Undefined,
+        backgroundStrokeWidth: float | UndefinedType = Undefined,
+        columns: float | UndefinedType = Undefined,
+        direction: LegendDirection_T | UndefinedType = Undefined,
+        labelLimit: float | UndefinedType = Undefined,
+        offset: float | UndefinedType = Undefined,
+        orient: LegendOrient_T
+        | core.ExprRef
+        | dict[str, Any]
+        | UndefinedType = Undefined,
+        padding: float | UndefinedType = Undefined,
+        style: str | Sequence[str] | None | UndefinedType = Undefined,
+        symbolSize: float | UndefinedType = Undefined,
+        symbolType: str | UndefinedType = Undefined,
+        title: str | None | UndefinedType = Undefined,
+        titleOrient: LegendTitleOrient_T | UndefinedType = Undefined,
+        values: Sequence[str | float | bool] | UndefinedType = Undefined,
+    ) -> YOffset:
+        """Return a channel with a ``Legend`` legend.
+
+        Args:
+            backgroundFill (str): Fill color of the legend background.
+            backgroundFillOpacity (float): Opacity of the legend background fill.
+            backgroundStroke (str): Stroke color of the legend background.
+            backgroundStrokeOpacity (float): Opacity of the legend background stroke.
+            backgroundStrokeWidth (float): Stroke width of the legend background border.
+            columns (float): The number of columns in which to arrange symbol legend entries.
+            direction (LegendDirection_T): The direction in which legend entries are laid out.
+            labelLimit (float): Maximum label text width in pixels.
+            offset (float): External gap in pixels between the legend and the plot edge.
+            orient (LegendOrient_T | ExprRef | dict[str, Any]): The plot side or inside corner where the legend is placed. Side legends are placed outside the plot area. Corner legends are placed inside the plot area.
+            padding (float): Internal padding in pixels around the legend content and background.
+            style (str | Sequence[str] | None): Named style reference or references resolved from ``config.style``. If an array is provided, later styles override earlier ones. Set to ``null`` to reset inherited legend styles.
+            symbolSize (float): Symbol size in pixels squared.
+            symbolType (str): Symbol shape.
+            title (str | None): Title text for the legend. If ``null``, the title is removed.
+            titleOrient (LegendTitleOrient_T): The side of the legend on which to place the title.
+            values (Sequence[str | float | bool]): Explicit values to show in the legend. For discrete symbol legends, the values define an ordered subset of entries. For quantitative symbol and gradient legends, the values define the shown representative values or ticks.
+        """
+        defined = {
+            "backgroundFill": backgroundFill,
+            "backgroundFillOpacity": backgroundFillOpacity,
+            "backgroundStroke": backgroundStroke,
+            "backgroundStrokeOpacity": backgroundStrokeOpacity,
+            "backgroundStrokeWidth": backgroundStrokeWidth,
+            "columns": columns,
+            "direction": direction,
+            "labelLimit": labelLimit,
+            "offset": offset,
+            "orient": orient,
+            "padding": padding,
+            "style": style,
+            "symbolSize": symbolSize,
+            "symbolType": symbolType,
+            "title": title,
+            "titleOrient": titleOrient,
+            "values": values,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_nested("legend", value, **defined)
+
+    def scale(
+        self,
+        value: Scale | ScaleKwds | None | object = Undefined,
+        /,
+        *,
+        align: float | UndefinedType = Undefined,
+        assembly: str
+        | core.UrlGenomeDefinition
+        | dict[str, Any]
+        | core.InlineGenomeDefinition
+        | UndefinedType = Undefined,
+        base: float | UndefinedType = Undefined,
+        bins: Sequence[float] | UndefinedType = Undefined,
+        clamp: bool | UndefinedType = Undefined,
+        constant: float | UndefinedType = Undefined,
+        domain: ScalarDomain_T
+        | Sequence[core.ChromosomalLocus | dict[str, Any]]
+        | core.SelectionDomainRef
+        | dict[str, Any]
+        | core.ExprRef
+        | Sequence[float | str | bool | core.ExprRef | dict[str, Any]]
+        | UndefinedType = Undefined,
+        domainMax: float | UndefinedType = Undefined,
+        domainMid: float | UndefinedType = Undefined,
+        domainMin: float | UndefinedType = Undefined,
+        domainTransition: bool | dict[str, Any] | UndefinedType = Undefined,
+        exponent: float | UndefinedType = Undefined,
+        interpolate: ScaleInterpolate_T
+        | core.ScaleInterpolateParams
+        | ScaleInterpolateParamsKwds
+        | UndefinedType = Undefined,
+        name: str | UndefinedType = Undefined,
+        nice: bool | float | dict[str, Any] | UndefinedType = Undefined,
+        numberingOffset: float | UndefinedType = Undefined,
+        padding: float | UndefinedType = Undefined,
+        paddingInner: float | UndefinedType = Undefined,
+        paddingOuter: float | UndefinedType = Undefined,
+        range: Sequence[float | str | core.ExprRef | dict[str, Any]]
+        | str
+        | UndefinedType = Undefined,
+        reverse: bool | UndefinedType = Undefined,
+        round: bool | UndefinedType = Undefined,
+        scheme: str | core.SchemeParams | SchemeParamsKwds | UndefinedType = Undefined,
+        type: ScaleType_T | UndefinedType = Undefined,
+        zero: bool | UndefinedType = Undefined,
+        zoom: bool | core.ZoomParams | ZoomParamsKwds | UndefinedType = Undefined,
+    ) -> YOffset:
+        """Return a channel with a ``Scale`` scale.
+
+        Args:
+            align (float): The alignment of the steps within the scale range. This value must lie in the range ``[0,1]``. A value of ``0.5`` indicates that the steps should be centered within the range. A value of ``0`` or ``1`` may be used to shift the bands to one side, say to position them adjacent to an axis. __Default value:__ ``0.5``
+            assembly (str | UrlGenomeDefinition | dict[str, Any] | InlineGenomeDefinition): Genome assembly definition for locus scales. This can be: - A string reference to a named assembly (built-in or root-configured). - An inline anonymous assembly that defines either ``contigs`` or ``url``. If undefined, the default genome from the genome store is used.
+            base (float): The logarithm base of the ``log`` scale (default ``10``).
+            bins (Sequence[float]): An array of bin boundaries over the scale domain. If provided, axes and legends will use the bin boundaries to inform the choice of tick marks and text labels.
+            clamp (bool): If ``true``, values that exceed the data domain are clamped to either the minimum or maximum range value __Default value:__ derived from the scale config's ``clamp`` (``true`` by default).
+            constant (float): A constant determining the slope of the symlog function around zero. Only used for ``symlog`` scales. __Default value:__ ``1``
+            domain (ScalarDomain_T | Sequence[ChromosomalLocus | dict[str, Any]] | SelectionDomainRef | dict[str, Any] | ExprRef | Sequence[float | str | bool | ExprRef | dict[str, Any]]): Customized domain values. For quantitative fields, ``domain`` can take the form of a two-element array with minimum and maximum values. Piecewise scales can be created by providing a ``domain`` with more than two entries. For temporal fields, ``domain`` can be a two-element array minimum and maximum values, in the form of either timestamps or the DateTime definition objects. For ordinal and nominal fields, ``domain`` can be an array that lists valid input values. The domain can also be defined by an expression reference that evaluates to the domain array. Array elements may also be expression references.
+            domainMax (float): Sets the maximum value in the scale domain, overriding the ``domain`` property. This property is only intended for use with scales having continuous domains.
+            domainMid (float): Inserts a single mid-point value into a two-element domain. The mid-point value must lie between the domain minimum and maximum values. This property can be useful for setting a midpoint for diverging color scales. The domainMid property is only intended for use with scales supporting continuous, piecewise domains.
+            domainMin (float): Sets the minimum value in the scale domain, overriding the domain property. This property is only intended for use with scales having continuous domains.
+            domainTransition (bool | dict[str, Any]): Controls whether domain updates are applied immediately or with a smooth transition. Set this to ``false`` to apply domain updates immediately. The default is ``true``, except for domains that include ``ExprRef``s, which default to ``false`` unless overridden. __Default value:__ ``true``, except ``false`` for ``ExprRef``-driven domains.
+            exponent (float): The exponent of the ``pow`` scale.
+            interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
+            name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
+            nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -7709,6 +8435,8 @@ __all__ = [
     "UniqueId",
     "X",
     "X2",
+    "XOffset",
     "Y",
     "Y2",
+    "YOffset",
 ]

--- a/src/genome_spy/schema/composition.py
+++ b/src/genome_spy/schema/composition.py
@@ -99,6 +99,7 @@ def layer(
         | core.CoverageParams
         | core.CoordinateLookupParams
         | core.CrossParams
+        | core.Displace1DParams
         | core.FlattenDelimitedParams
         | core.FormulaParams
         | core.LookupParams
@@ -179,7 +180,7 @@ def layer(
         templates (dict[str, Any]): Schema-defined ``templates`` property.
         theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
         title (str | Title | TitleKwds): View title.
-        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
         view (ViewBackground | ViewBackgroundKwds): Schema-defined ``view`` property.
         viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
         viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -288,6 +289,7 @@ def hconcat(
         | core.CoverageParams
         | core.CoordinateLookupParams
         | core.CrossParams
+        | core.Displace1DParams
         | core.FlattenDelimitedParams
         | core.FormulaParams
         | core.LookupParams
@@ -368,7 +370,7 @@ def hconcat(
         templates (dict[str, Any]): Schema-defined ``templates`` property.
         theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
         title (str | Title | TitleKwds): View title.
-        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
         viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
         viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
         visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -476,6 +478,7 @@ def vconcat(
         | core.CoverageParams
         | core.CoordinateLookupParams
         | core.CrossParams
+        | core.Displace1DParams
         | core.FlattenDelimitedParams
         | core.FormulaParams
         | core.LookupParams
@@ -556,7 +559,7 @@ def vconcat(
         templates (dict[str, Any]): Schema-defined ``templates`` property.
         theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
         title (str | Title | TitleKwds): View title.
-        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
         viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
         viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
         visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -665,6 +668,7 @@ def concat(
         | core.CoverageParams
         | core.CoordinateLookupParams
         | core.CrossParams
+        | core.Displace1DParams
         | core.FlattenDelimitedParams
         | core.FormulaParams
         | core.LookupParams
@@ -746,7 +750,7 @@ def concat(
         templates (dict[str, Any]): Schema-defined ``templates`` property.
         theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
         title (str | Title | TitleKwds): View title.
-        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
         viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
         viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
         visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -860,6 +864,7 @@ def multiscale(
         | core.CoverageParams
         | core.CoordinateLookupParams
         | core.CrossParams
+        | core.Displace1DParams
         | core.FlattenDelimitedParams
         | core.FormulaParams
         | core.LookupParams
@@ -941,7 +946,7 @@ def multiscale(
         templates (dict[str, Any]): Schema-defined ``templates`` property.
         theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
         title (str | Title | TitleKwds): View title.
-        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+        transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
         view (ViewBackground | ViewBackgroundKwds): Schema-defined ``view`` property.
         viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
         viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)

--- a/src/genome_spy/schema/core.py
+++ b/src/genome_spy/schema/core.py
@@ -324,10 +324,12 @@ class ArrowConfig(GenomeSpySchema):
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -360,9 +362,11 @@ class ArrowConfig(GenomeSpySchema):
             tooltip=tooltip,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -786,9 +790,41 @@ class ArrowConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> ArrowConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> ArrowConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> ArrowConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -826,9 +862,41 @@ class ArrowConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> ArrowConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> ArrowConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> ArrowConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class ArrowDirection(GenomeSpySchema):
@@ -910,10 +978,12 @@ class ArrowProps(GenomeSpySchema):
         type: Literal["arrow"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -947,9 +1017,11 @@ class ArrowProps(GenomeSpySchema):
             type=type,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -1377,9 +1449,41 @@ class ArrowProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> ArrowProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> ArrowProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> ArrowProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -1417,9 +1521,41 @@ class ArrowProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> ArrowProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> ArrowProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> ArrowProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class ArrowRelativeSize(GenomeSpySchema):
@@ -1488,6 +1624,7 @@ class Axis(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -1542,6 +1679,7 @@ class Axis(GenomeSpySchema):
             domainDash=domainDash,
             domainDashOffset=domainDashOffset,
             domainWidth=domainWidth,
+            extraValues=extraValues,
             format=format,
             grid=grid,
             gridCap=gridCap,
@@ -1614,6 +1752,10 @@ class Axis(GenomeSpySchema):
     def domainWidth(self, value: float) -> Axis:
         """Return a copy with ``domainWidth`` updated."""
         return self._with_property("domainWidth", value)
+
+    def extraValues(self, value: Sequence[float]) -> Axis:
+        """Return a copy with ``extraValues`` updated."""
+        return self._with_property("extraValues", value)
 
     def format(self, value: str) -> Axis:
         """Return a copy with ``format`` updated."""
@@ -1846,6 +1988,7 @@ class AxisConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -1923,6 +2066,7 @@ class AxisConfig(GenomeSpySchema):
             domainDash=domainDash,
             domainDashOffset=domainDashOffset,
             domainWidth=domainWidth,
+            extraValues=extraValues,
             format=format,
             grid=grid,
             gridCap=gridCap,
@@ -2087,6 +2231,10 @@ class AxisConfig(GenomeSpySchema):
     def domainWidth(self, value: float) -> AxisConfig:
         """Return a copy with ``domainWidth`` updated."""
         return self._with_property("domainWidth", value)
+
+    def extraValues(self, value: Sequence[float]) -> AxisConfig:
+        """Return a copy with ``extraValues`` updated."""
+        return self._with_property("extraValues", value)
 
     def format(self, value: str) -> AxisConfig:
         """Return a copy with ``format`` updated."""
@@ -2356,6 +2504,7 @@ class AxisTicksData(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -2411,6 +2560,7 @@ class AxisTicksData(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -2464,6 +2614,7 @@ class AxisTicksData(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -3479,6 +3630,7 @@ class ChromPosDef(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -3557,6 +3709,7 @@ class ChromPosDef(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -3633,6 +3786,7 @@ class ChromPosDef(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -3775,7 +3929,7 @@ class ChromPosDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -4125,7 +4279,7 @@ class ColorDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -4333,6 +4487,7 @@ class ConcatSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -4695,6 +4850,14 @@ class ConcatSpec(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -4704,6 +4867,14 @@ class ConcatSpec(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
     ) -> ConcatSpec:
         """Return a copy with a ``Encoding`` encoding.
 
@@ -4711,8 +4882,8 @@ class ConcatSpec(GenomeSpySchema):
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -4721,7 +4892,7 @@ class ConcatSpec(GenomeSpySchema):
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -4731,8 +4902,10 @@ class ConcatSpec(GenomeSpySchema):
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         defined = {
             "angle": angle,
@@ -4758,8 +4931,10 @@ class ConcatSpec(GenomeSpySchema):
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("encoding", value, **defined)
@@ -4891,10 +5066,12 @@ class ConcatSpec(GenomeSpySchema):
         type: Literal["rule"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         zindex: float | UndefinedType = Undefined,
     ) -> ConcatSpec:
         """Return a copy with a ``SeparatorProps`` separator.
@@ -4918,10 +5095,12 @@ class ConcatSpec(GenomeSpySchema):
             type (Literal['rule']): Schema-defined ``type`` property.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
             zindex (float): Z-order of the separator relative to the view content. Values greater than ``0`` render after the view marks. Values less than or equal to ``0`` render before the marks. __Default value:__ ``0``
         """
         defined = {
@@ -4943,9 +5122,11 @@ class ConcatSpec(GenomeSpySchema):
             "type": type,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
             "zindex": zindex,
         }
@@ -5060,6 +5241,7 @@ class ConcatSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -5374,7 +5556,7 @@ class ConditionalMarkPropExprDefType(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -5625,7 +5807,7 @@ class ConditionalMarkPropExprDefTypeForShape(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -5876,7 +6058,7 @@ class ConditionalMarkPropFieldDefType(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -6127,7 +6309,7 @@ class ConditionalMarkPropFieldDefTypeForShape(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -6308,7 +6490,7 @@ class ConditionalScaleDatumDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -6673,7 +6855,7 @@ class ConditionalParameterMarkPropExprDefType(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -6928,7 +7110,7 @@ class ConditionalParameterMarkPropExprDefTypeForShape(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -7181,7 +7363,7 @@ class ConditionalParameterMarkPropFieldDefType(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -7436,7 +7618,7 @@ class ConditionalParameterMarkPropFieldDefTypeForShape(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -7625,7 +7807,7 @@ class ConditionalParameterScaleDatumDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -7831,6 +8013,7 @@ class CoordinateLookupInput(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -7894,6 +8077,7 @@ class CoordinateLookupInput(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -7991,6 +8175,7 @@ class CoordinateLookupParams(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -8022,7 +8207,7 @@ class CoordinateLookupParams(GenomeSpySchema):
 
         Args:
             data (LazyData | dict[str, Any]): The lazy side data source.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): Transforms applied to the side data before lookup.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): Transforms applied to the side data before lookup.
         """
         defined = {
             "data": data,
@@ -8169,6 +8354,7 @@ class CoreRootSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -8564,6 +8750,14 @@ class CoreRootSpec(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -8573,6 +8767,14 @@ class CoreRootSpec(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
     ) -> CoreRootSpec:
         """Return a copy with a ``Encoding`` encoding.
 
@@ -8580,8 +8782,8 @@ class CoreRootSpec(GenomeSpySchema):
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -8590,7 +8792,7 @@ class CoreRootSpec(GenomeSpySchema):
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -8600,8 +8802,10 @@ class CoreRootSpec(GenomeSpySchema):
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         defined = {
             "angle": angle,
@@ -8627,8 +8831,10 @@ class CoreRootSpec(GenomeSpySchema):
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("encoding", value, **defined)
@@ -8827,10 +9033,12 @@ class CoreRootSpec(GenomeSpySchema):
         type: Literal["rule"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         zindex: float | UndefinedType = Undefined,
     ) -> CoreRootSpec:
         """Return a copy with a ``SeparatorProps`` separator.
@@ -8854,10 +9062,12 @@ class CoreRootSpec(GenomeSpySchema):
             type (Literal['rule']): Schema-defined ``type`` property.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
             zindex (float): Z-order of the separator relative to the view content. Values greater than ``0`` render after the view marks. Values less than or equal to ``0`` render before the marks. __Default value:__ ``0``
         """
         defined = {
@@ -8879,9 +9089,11 @@ class CoreRootSpec(GenomeSpySchema):
             "type": type,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
             "zindex": zindex,
         }
@@ -9012,6 +9224,7 @@ class CoreRootSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -9286,6 +9499,7 @@ class CrossData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat
         | UndefinedType = Undefined,
@@ -9324,6 +9538,7 @@ class CrossData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat,
     ) -> CrossData:
@@ -9399,6 +9614,7 @@ class CrossInput(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -9448,6 +9664,7 @@ class CrossInput(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -9517,6 +9734,7 @@ class CrossParams(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -9548,7 +9766,7 @@ class CrossParams(GenomeSpySchema):
 
         Args:
             data (UrlData | dict[str, Any] | InlineData | NamedData | SequenceGenerator): Finite eager data crossed with the primary input.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): Unary transforms applied to the foreign data before crossing.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): Unary transforms applied to the foreign data before crossing.
         """
         defined = {
             "data": data,
@@ -9611,6 +9829,7 @@ class Data(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat
         | UndefinedType = Undefined,
@@ -9656,6 +9875,7 @@ class Data(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat,
     ) -> Data:
@@ -9856,6 +10076,7 @@ class DataSource(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat
         | UndefinedType = Undefined,
@@ -9899,6 +10120,7 @@ class DataSource(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat,
     ) -> DataSource:
@@ -10136,7 +10358,7 @@ class DirectionDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -10190,6 +10412,93 @@ class DirectionDef(GenomeSpySchema):
     def value(self, value: ArrowDirection_T | ExprRef | dict[str, Any]) -> DirectionDef:
         """Return a copy with ``value`` updated."""
         return self._with_property("value", value)
+
+
+class Displace1DParams(GenomeSpySchema):
+    """Generated wrapper for ``Displace1DParams``."""
+
+    _schema = _ROOT_SCHEMA.get("definitions", {}).get("Displace1DParams", {})
+
+    def __init__(
+        self,
+        as_: str | UndefinedType = Undefined,
+        description: str | UndefinedType = Undefined,
+        extent: Sequence[float] | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        length: float | Field_T | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        pos: Field_T | UndefinedType = Undefined,
+        positionFactor: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        type: Literal["displace1d"] | UndefinedType = Undefined,
+        **kwds: Any,
+    ) -> None:
+        super().__init__(
+            description=description,
+            extent=extent,
+            length=length,
+            pos=pos,
+            positionFactor=positionFactor,
+            type=type,
+            **{"as": as_},
+        )
+        if kwds:
+            self._kwds.update(kwds)
+
+    def as_(self, value: str) -> Displace1DParams:
+        """Return a copy with ``as`` updated."""
+        return self._with_property("as", value)
+
+    def description(self, value: str) -> Displace1DParams:
+        """Return a copy with ``description`` updated."""
+        return self._with_property("description", value)
+
+    def extent(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> Displace1DParams:
+        """Return a copy with a ``ExprRef`` extent.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("extent", value, **defined)
+
+    def length(
+        self, value: float | Field_T | ExprRef | dict[str, Any]
+    ) -> Displace1DParams:
+        """Return a copy with ``length`` updated."""
+        return self._with_property("length", value)
+
+    def pos(self, value: Field_T) -> Displace1DParams:
+        """Return a copy with ``pos`` updated."""
+        return self._with_property("pos", value)
+
+    def positionFactor(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> Displace1DParams:
+        """Return a copy with a ``ExprRef`` positionFactor.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("positionFactor", value, **defined)
+
+    def type(self, value: Literal["displace1d"]) -> Displace1DParams:
+        """Return a copy with ``type`` updated."""
+        return self._with_property("type", value)
 
 
 class DomEventType(GenomeSpySchema):
@@ -10283,6 +10592,7 @@ class DynamicCallbackData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat
         | UndefinedType = Undefined,
@@ -10314,6 +10624,7 @@ class DynamicCallbackData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat,
     ) -> DynamicCallbackData:
@@ -10473,6 +10784,14 @@ class Encoding(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -10482,6 +10801,14 @@ class Encoding(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -10508,8 +10835,10 @@ class Encoding(GenomeSpySchema):
             uniqueId=uniqueId,
             x=x,
             x2=x2,
+            xOffset=xOffset,
             y=y,
             y2=y2,
+            yOffset=yOffset,
         )
         if kwds:
             self._kwds.update(kwds)
@@ -10874,6 +11203,19 @@ class Encoding(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
+    def xOffset(
+        self,
+        value: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None,
+    ) -> Encoding:
+        """Return a copy with ``xOffset`` updated."""
+        return self._with_property("xOffset", value)
+
     def y(
         self,
         value: PositionFieldDef
@@ -10943,6 +11285,19 @@ class Encoding(GenomeSpySchema):
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
+
+    def yOffset(
+        self,
+        value: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None,
+    ) -> Encoding:
+        """Return a copy with ``yOffset`` updated."""
+        return self._with_property("yOffset", value)
 
 
 class EventConfig(GenomeSpySchema):
@@ -11405,7 +11760,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull(GenomeSpySchema
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -11670,7 +12025,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -11937,7 +12292,7 @@ class FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull(
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -12132,7 +12487,7 @@ class FieldOrDatumDefWithConditionScaleDatumDefStringNull(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -12327,7 +12682,7 @@ class FieldOrDatumDefWithConditionScaleDatumDefNumber(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -12865,6 +13220,7 @@ class GenomeAxis(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -12942,6 +13298,7 @@ class GenomeAxis(GenomeSpySchema):
             domainDash=domainDash,
             domainDashOffset=domainDashOffset,
             domainWidth=domainWidth,
+            extraValues=extraValues,
             format=format,
             grid=grid,
             gridCap=gridCap,
@@ -13106,6 +13463,10 @@ class GenomeAxis(GenomeSpySchema):
     def domainWidth(self, value: float) -> GenomeAxis:
         """Return a copy with ``domainWidth`` updated."""
         return self._with_property("domainWidth", value)
+
+    def extraValues(self, value: Sequence[float]) -> GenomeAxis:
+        """Return a copy with ``extraValues`` updated."""
+        return self._with_property("extraValues", value)
 
     def format(self, value: str) -> GenomeAxis:
         """Return a copy with ``format`` updated."""
@@ -13503,10 +13864,12 @@ class GenomeSpyConfig(GenomeSpySchema):
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> GenomeSpyConfig:
         """Return a copy with a ``ArrowConfig`` arrow.
 
@@ -13540,10 +13903,12 @@ class GenomeSpyConfig(GenomeSpySchema):
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -13575,9 +13940,11 @@ class GenomeSpyConfig(GenomeSpySchema):
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -13617,6 +13984,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -13695,6 +14063,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -13771,6 +14140,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -13854,6 +14224,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -13932,6 +14303,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -14008,6 +14380,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -14091,6 +14464,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -14169,6 +14543,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -14245,6 +14620,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -14328,6 +14704,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -14406,6 +14783,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -14482,6 +14860,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -14565,6 +14944,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -14643,6 +15023,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -14719,6 +15100,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -14802,6 +15184,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -14880,6 +15263,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -14956,6 +15340,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -15039,6 +15424,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -15117,6 +15503,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -15193,6 +15580,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -15276,6 +15664,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -15354,6 +15743,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -15430,6 +15820,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -15513,6 +15904,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -15591,6 +15983,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -15667,6 +16060,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -15750,6 +16144,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -15828,6 +16223,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -15904,6 +16300,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -15987,6 +16384,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -16065,6 +16463,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -16141,6 +16540,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -16224,6 +16624,7 @@ class GenomeSpyConfig(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -16302,6 +16703,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -16378,6 +16780,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -16752,10 +17155,12 @@ class GenomeSpyConfig(GenomeSpySchema):
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> GenomeSpyConfig:
         """Return a copy with a ``LinkConfig`` link.
 
@@ -16782,10 +17187,12 @@ class GenomeSpyConfig(GenomeSpySchema):
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "arcFadingDistance": arcFadingDistance,
@@ -16810,9 +17217,11 @@ class GenomeSpyConfig(GenomeSpySchema):
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -16844,9 +17253,11 @@ class GenomeSpyConfig(GenomeSpySchema):
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> GenomeSpyConfig:
         """Return a copy with a ``MarkConfig`` mark.
 
@@ -16861,9 +17272,11 @@ class GenomeSpyConfig(GenomeSpySchema):
             style (str | Sequence[str]): Named style reference(s) resolved from ``config.style``. If an array is provided, later styles override earlier ones.
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -16876,8 +17289,10 @@ class GenomeSpyConfig(GenomeSpySchema):
             "style": style,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -16933,9 +17348,11 @@ class GenomeSpyConfig(GenomeSpySchema):
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> GenomeSpyConfig:
         """Return a copy with a ``PointConfig`` point.
 
@@ -16960,7 +17377,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             sampleFacetPadding (float): Additional padding used by sample facets. **Default value:** ``0.1``
             semanticScore (float | ExprRef | dict[str, Any]): The semantic score used by semantic zooming in the point mark. This is primarily intended for internal use. **Default value:** ``0``
             semanticZoomFraction (float | ExprRef | dict[str, Any]): TODO **Default value:** ``0.02``
-            shape (str | ExprRef | dict[str, Any]): One of ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, ``"triangle-left"``, ``"tick-up"``, ``"tick-down"``, ``"tick-right"``, or ``"tick-left"`` **Default value:** ``"circle"``
+            shape (str | ExprRef | dict[str, Any]): One of ``"circle"``, ``"square"``, ``"cross"``, ``"x"``, ``"+"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, ``"triangle-left"``, ``"tick-up"``, ``"tick-down"``, ``"tick-right"``, or ``"tick-left"``. The ``"x"`` and ``"+"`` shapes are stroke-only and use ``strokeWidth`` for their line thickness. **Default value:** ``"circle"``
             size (float | ExprRef | dict[str, Any]): Stroke width of ``"link"`` and ``"rule"`` marks in pixels, the area of the bounding square of ``"point"`` mark, or the font size of ``"text"`` mark.
             stroke (str | ExprRef | dict[str, Any]): The stroke color
             strokeOpacity (float | ExprRef | dict[str, Any]): The stroke opacity. Value between ``0`` and ``1``.
@@ -16968,9 +17385,11 @@ class GenomeSpyConfig(GenomeSpySchema):
             style (str | Sequence[str]): Named style reference(s) resolved from ``config.style``. If an array is provided, later styles override earlier ones.
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "angle": angle,
@@ -17001,8 +17420,10 @@ class GenomeSpyConfig(GenomeSpySchema):
             "style": style,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -17112,10 +17533,12 @@ class GenomeSpyConfig(GenomeSpySchema):
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> GenomeSpyConfig:
         """Return a copy with a ``RectConfig`` rect.
 
@@ -17151,10 +17574,12 @@ class GenomeSpyConfig(GenomeSpySchema):
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -17188,9 +17613,11 @@ class GenomeSpyConfig(GenomeSpySchema):
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -17233,10 +17660,12 @@ class GenomeSpyConfig(GenomeSpySchema):
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> GenomeSpyConfig:
         """Return a copy with a ``RuleConfig`` rule.
 
@@ -17257,10 +17686,12 @@ class GenomeSpyConfig(GenomeSpySchema):
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -17279,9 +17710,11 @@ class GenomeSpyConfig(GenomeSpySchema):
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -17373,7 +17806,7 @@ class GenomeSpyConfig(GenomeSpySchema):
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
             nominal (dict[str, Any]): Defaults for nominal scales.
             nominalColorScheme (str | SchemeParams | SchemeParamsKwds): Default color scheme for nominal color scales.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             ordinal (dict[str, Any]): Defaults for ordinal scales.
             ordinalColorScheme (str | SchemeParams | SchemeParamsKwds): Default color scheme for ordinal color scales.
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
@@ -17484,10 +17917,12 @@ class GenomeSpyConfig(GenomeSpySchema):
         viewportEdgeFadeWidthTop: float | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> GenomeSpyConfig:
         """Return a copy with a ``TextConfig`` text.
 
@@ -17528,10 +17963,12 @@ class GenomeSpyConfig(GenomeSpySchema):
             viewportEdgeFadeWidthTop (float): Schema-defined ``viewportEdgeFadeWidthTop`` property.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "align": align,
@@ -17570,9 +18007,11 @@ class GenomeSpyConfig(GenomeSpySchema):
             "viewportEdgeFadeWidthTop": viewportEdgeFadeWidthTop,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -17615,9 +18054,11 @@ class GenomeSpyConfig(GenomeSpySchema):
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> GenomeSpyConfig:
         """Return a copy with a ``TickConfig`` tick.
 
@@ -17638,9 +18079,11 @@ class GenomeSpyConfig(GenomeSpySchema):
             thickness (float): The thickness of the tick mark in pixels. Equivalent to the ``size`` of the underlying rule mark. **Default value:** ``1``
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -17659,8 +18102,10 @@ class GenomeSpyConfig(GenomeSpySchema):
             "thickness": thickness,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -18006,6 +18451,7 @@ class HConcatSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -18347,6 +18793,14 @@ class HConcatSpec(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -18356,6 +18810,14 @@ class HConcatSpec(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
     ) -> HConcatSpec:
         """Return a copy with a ``Encoding`` encoding.
 
@@ -18363,8 +18825,8 @@ class HConcatSpec(GenomeSpySchema):
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -18373,7 +18835,7 @@ class HConcatSpec(GenomeSpySchema):
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -18383,8 +18845,10 @@ class HConcatSpec(GenomeSpySchema):
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         defined = {
             "angle": angle,
@@ -18410,8 +18874,10 @@ class HConcatSpec(GenomeSpySchema):
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("encoding", value, **defined)
@@ -18559,10 +19025,12 @@ class HConcatSpec(GenomeSpySchema):
         type: Literal["rule"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         zindex: float | UndefinedType = Undefined,
     ) -> HConcatSpec:
         """Return a copy with a ``SeparatorProps`` separator.
@@ -18586,10 +19054,12 @@ class HConcatSpec(GenomeSpySchema):
             type (Literal['rule']): Schema-defined ``type`` property.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
             zindex (float): Z-order of the separator relative to the view content. Values greater than ``0`` render after the view marks. Values less than or equal to ``0`` render before the marks. __Default value:__ ``0``
         """
         defined = {
@@ -18611,9 +19081,11 @@ class HConcatSpec(GenomeSpySchema):
             "type": type,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
             "zindex": zindex,
         }
@@ -18728,6 +19200,7 @@ class HConcatSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -19225,6 +19698,7 @@ class InlineData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat
         | UndefinedType = Undefined,
@@ -19250,6 +19724,7 @@ class InlineData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat,
     ) -> InlineData:
@@ -19623,6 +20098,7 @@ class LayerSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -19965,6 +20441,14 @@ class LayerSpec(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -19974,6 +20458,14 @@ class LayerSpec(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
     ) -> LayerSpec:
         """Return a copy with a ``Encoding`` encoding.
 
@@ -19981,8 +20473,8 @@ class LayerSpec(GenomeSpySchema):
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -19991,7 +20483,7 @@ class LayerSpec(GenomeSpySchema):
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -20001,8 +20493,10 @@ class LayerSpec(GenomeSpySchema):
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         defined = {
             "angle": angle,
@@ -20028,8 +20522,10 @@ class LayerSpec(GenomeSpySchema):
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("encoding", value, **defined)
@@ -20242,6 +20738,7 @@ class LayerSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -20589,6 +21086,7 @@ class LazyDataParams(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -20644,6 +21142,7 @@ class LazyDataParams(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -20697,6 +21196,7 @@ class LazyDataParams(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -21432,10 +21932,12 @@ class LinkConfig(GenomeSpySchema):
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -21461,9 +21963,11 @@ class LinkConfig(GenomeSpySchema):
             tooltip=tooltip,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -21787,9 +22291,41 @@ class LinkConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> LinkConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> LinkConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> LinkConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -21827,9 +22363,41 @@ class LinkConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> LinkConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> LinkConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> LinkConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class LinkProps(GenomeSpySchema):
@@ -21890,10 +22458,12 @@ class LinkProps(GenomeSpySchema):
         type: Literal["link"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -21920,9 +22490,11 @@ class LinkProps(GenomeSpySchema):
             type=type,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -22250,9 +22822,41 @@ class LinkProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> LinkProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> LinkProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> LinkProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -22290,9 +22894,41 @@ class LinkProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> LinkProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> LinkProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> LinkProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class LookupParams(GenomeSpySchema):
@@ -22418,9 +23054,11 @@ class MarkConfig(GenomeSpySchema):
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -22434,8 +23072,10 @@ class MarkConfig(GenomeSpySchema):
             style=style,
             tooltip=tooltip,
             x=x,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -22543,9 +23183,41 @@ class MarkConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x", value, **defined)
 
-    def xOffset(self, value: float) -> MarkConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> MarkConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> MarkConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -22565,9 +23237,41 @@ class MarkConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y", value, **defined)
 
-    def yOffset(self, value: float) -> MarkConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> MarkConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> MarkConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class MarkPropDefStringNullTypeForShape(GenomeSpySchema):
@@ -22799,7 +23503,7 @@ class MarkPropDefStringNullTypeForShape(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -23094,7 +23798,7 @@ class MarkPropDefStringNull(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -23387,7 +24091,7 @@ class MarkPropDefNumber(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -23640,7 +24344,7 @@ class MarkPropExprDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -23875,7 +24579,7 @@ class MarkPropExprDefType(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -24114,7 +24818,7 @@ class MarkPropExprDefTypeForShape(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -24342,10 +25046,12 @@ class MarkProps(GenomeSpySchema):
         viewportEdgeFadeWidthTop: float | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -24439,9 +25145,11 @@ class MarkProps(GenomeSpySchema):
             viewportEdgeFadeWidthTop=viewportEdgeFadeWidthTop,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -25695,9 +26403,41 @@ class MarkProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> MarkProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> MarkProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> MarkProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -25735,9 +26475,41 @@ class MarkProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> MarkProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> MarkProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> MarkProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class MarkType(GenomeSpySchema):
@@ -25998,6 +26770,7 @@ class MultiscaleSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -26341,6 +27114,14 @@ class MultiscaleSpec(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -26350,6 +27131,14 @@ class MultiscaleSpec(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
     ) -> MultiscaleSpec:
         """Return a copy with a ``Encoding`` encoding.
 
@@ -26357,8 +27146,8 @@ class MultiscaleSpec(GenomeSpySchema):
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -26367,7 +27156,7 @@ class MultiscaleSpec(GenomeSpySchema):
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -26377,8 +27166,10 @@ class MultiscaleSpec(GenomeSpySchema):
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         defined = {
             "angle": angle,
@@ -26404,8 +27195,10 @@ class MultiscaleSpec(GenomeSpySchema):
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("encoding", value, **defined)
@@ -26628,6 +27421,7 @@ class MultiscaleSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -26905,6 +27699,7 @@ class NamedData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat
         | UndefinedType = Undefined,
@@ -26927,6 +27722,7 @@ class NamedData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat,
     ) -> NamedData:
@@ -27196,7 +27992,7 @@ class NumericMarkPropDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -27312,6 +28108,310 @@ class NumericValueDef(GenomeSpySchema):
         *,
         expr: str | UndefinedType = Undefined,
     ) -> NumericValueDef:
+        """Return a copy with a ``ExprRef`` value.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("value", value, **defined)
+
+
+class OffsetChannel(GenomeSpySchema):
+    """Generated wrapper for ``OffsetChannel``."""
+
+    _schema = _ROOT_SCHEMA.get("definitions", {}).get("OffsetChannel", {})
+
+    def __init__(self, **kwds: Any) -> None:
+        super().__init__()
+        if kwds:
+            self._kwds.update(kwds)
+
+
+class OffsetDef(GenomeSpySchema):
+    """Generated wrapper for ``OffsetDef``."""
+
+    _schema = _ROOT_SCHEMA.get("definitions", {}).get("OffsetDef", {})
+
+    def __init__(
+        self,
+        band: float | UndefinedType = Undefined,
+        condition: ConditionalParameterMarkPropFieldDefType
+        | dict[str, Any]
+        | ConditionalParameterScaleDatumDef
+        | ConditionalParameterMarkPropExprDefType
+        | ConditionalParameterValueDefNumberExprRef
+        | Sequence[ConditionalParameterValueDefNumberExprRef | dict[str, Any]]
+        | UndefinedType = Undefined,
+        datum: Scalar_T | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        description: str | UndefinedType = Undefined,
+        domainInert: bool | UndefinedType = Undefined,
+        expr: str | UndefinedType = Undefined,
+        field: str | UndefinedType = Undefined,
+        format: str | UndefinedType = Undefined,
+        legend: Legend | LegendKwds | None | UndefinedType = Undefined,
+        resolutionChannel: ChannelWithScale_T | UndefinedType = Undefined,
+        scale: Scale | ScaleKwds | None | UndefinedType = Undefined,
+        title: str | None | UndefinedType = Undefined,
+        type: Type_T | UndefinedType = Undefined,
+        value: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        **kwds: Any,
+    ) -> None:
+        super().__init__(
+            band=band,
+            condition=condition,
+            datum=datum,
+            description=description,
+            domainInert=domainInert,
+            expr=expr,
+            field=field,
+            format=format,
+            legend=legend,
+            resolutionChannel=resolutionChannel,
+            scale=scale,
+            title=title,
+            type=type,
+            value=value,
+        )
+        if kwds:
+            self._kwds.update(kwds)
+
+    def band(self, value: float) -> OffsetDef:
+        """Return a copy with ``band`` updated."""
+        return self._with_property("band", value)
+
+    def condition(
+        self,
+        value: ConditionalParameterMarkPropFieldDefType
+        | dict[str, Any]
+        | ConditionalParameterScaleDatumDef
+        | ConditionalParameterMarkPropExprDefType
+        | ConditionalParameterValueDefNumberExprRef
+        | Sequence[ConditionalParameterValueDefNumberExprRef | dict[str, Any]],
+    ) -> OffsetDef:
+        """Return a copy with ``condition`` updated."""
+        return self._with_property("condition", value)
+
+    def datum(self, value: Scalar_T | ExprRef | dict[str, Any]) -> OffsetDef:
+        """Return a copy with ``datum`` updated."""
+        return self._with_property("datum", value)
+
+    def description(self, value: str) -> OffsetDef:
+        """Return a copy with ``description`` updated."""
+        return self._with_property("description", value)
+
+    def domainInert(self, value: bool) -> OffsetDef:
+        """Return a copy with ``domainInert`` updated."""
+        return self._with_property("domainInert", value)
+
+    def expr(self, value: str) -> OffsetDef:
+        """Return a copy with ``expr`` updated."""
+        return self._with_property("expr", value)
+
+    def field(self, value: str) -> OffsetDef:
+        """Return a copy with ``field`` updated."""
+        return self._with_property("field", value)
+
+    def format(self, value: str) -> OffsetDef:
+        """Return a copy with ``format`` updated."""
+        return self._with_property("format", value)
+
+    def legend(
+        self,
+        value: Legend | LegendKwds | None | object = Undefined,
+        /,
+        *,
+        backgroundFill: str | UndefinedType = Undefined,
+        backgroundFillOpacity: float | UndefinedType = Undefined,
+        backgroundStroke: str | UndefinedType = Undefined,
+        backgroundStrokeOpacity: float | UndefinedType = Undefined,
+        backgroundStrokeWidth: float | UndefinedType = Undefined,
+        columns: float | UndefinedType = Undefined,
+        direction: LegendDirection_T | UndefinedType = Undefined,
+        labelLimit: float | UndefinedType = Undefined,
+        offset: float | UndefinedType = Undefined,
+        orient: LegendOrient_T | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        padding: float | UndefinedType = Undefined,
+        style: str | Sequence[str] | None | UndefinedType = Undefined,
+        symbolSize: float | UndefinedType = Undefined,
+        symbolType: str | UndefinedType = Undefined,
+        title: str | None | UndefinedType = Undefined,
+        titleOrient: LegendTitleOrient_T | UndefinedType = Undefined,
+        values: Sequence[str | float | bool] | UndefinedType = Undefined,
+    ) -> OffsetDef:
+        """Return a copy with a ``Legend`` legend.
+
+        Args:
+            backgroundFill (str): Fill color of the legend background.
+            backgroundFillOpacity (float): Opacity of the legend background fill.
+            backgroundStroke (str): Stroke color of the legend background.
+            backgroundStrokeOpacity (float): Opacity of the legend background stroke.
+            backgroundStrokeWidth (float): Stroke width of the legend background border.
+            columns (float): The number of columns in which to arrange symbol legend entries.
+            direction (LegendDirection_T): The direction in which legend entries are laid out.
+            labelLimit (float): Maximum label text width in pixels.
+            offset (float): External gap in pixels between the legend and the plot edge.
+            orient (LegendOrient_T | ExprRef | dict[str, Any]): The plot side or inside corner where the legend is placed. Side legends are placed outside the plot area. Corner legends are placed inside the plot area.
+            padding (float): Internal padding in pixels around the legend content and background.
+            style (str | Sequence[str] | None): Named style reference or references resolved from ``config.style``. If an array is provided, later styles override earlier ones. Set to ``null`` to reset inherited legend styles.
+            symbolSize (float): Symbol size in pixels squared.
+            symbolType (str): Symbol shape.
+            title (str | None): Title text for the legend. If ``null``, the title is removed.
+            titleOrient (LegendTitleOrient_T): The side of the legend on which to place the title.
+            values (Sequence[str | float | bool]): Explicit values to show in the legend. For discrete symbol legends, the values define an ordered subset of entries. For quantitative symbol and gradient legends, the values define the shown representative values or ticks.
+        """
+        defined = {
+            "backgroundFill": backgroundFill,
+            "backgroundFillOpacity": backgroundFillOpacity,
+            "backgroundStroke": backgroundStroke,
+            "backgroundStrokeOpacity": backgroundStrokeOpacity,
+            "backgroundStrokeWidth": backgroundStrokeWidth,
+            "columns": columns,
+            "direction": direction,
+            "labelLimit": labelLimit,
+            "offset": offset,
+            "orient": orient,
+            "padding": padding,
+            "style": style,
+            "symbolSize": symbolSize,
+            "symbolType": symbolType,
+            "title": title,
+            "titleOrient": titleOrient,
+            "values": values,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("legend", value, **defined)
+
+    def resolutionChannel(self, value: ChannelWithScale_T) -> OffsetDef:
+        """Return a copy with ``resolutionChannel`` updated."""
+        return self._with_property("resolutionChannel", value)
+
+    def scale(
+        self,
+        value: Scale | ScaleKwds | None | object = Undefined,
+        /,
+        *,
+        align: float | UndefinedType = Undefined,
+        assembly: str
+        | UrlGenomeDefinition
+        | dict[str, Any]
+        | InlineGenomeDefinition
+        | UndefinedType = Undefined,
+        base: float | UndefinedType = Undefined,
+        bins: Sequence[float] | UndefinedType = Undefined,
+        clamp: bool | UndefinedType = Undefined,
+        constant: float | UndefinedType = Undefined,
+        domain: ScalarDomain_T
+        | Sequence[ChromosomalLocus | dict[str, Any]]
+        | SelectionDomainRef
+        | dict[str, Any]
+        | ExprRef
+        | Sequence[float | str | bool | ExprRef | dict[str, Any]]
+        | UndefinedType = Undefined,
+        domainMax: float | UndefinedType = Undefined,
+        domainMid: float | UndefinedType = Undefined,
+        domainMin: float | UndefinedType = Undefined,
+        domainTransition: bool | dict[str, Any] | UndefinedType = Undefined,
+        exponent: float | UndefinedType = Undefined,
+        interpolate: ScaleInterpolate_T
+        | ScaleInterpolateParams
+        | ScaleInterpolateParamsKwds
+        | UndefinedType = Undefined,
+        name: str | UndefinedType = Undefined,
+        nice: bool | float | dict[str, Any] | UndefinedType = Undefined,
+        numberingOffset: float | UndefinedType = Undefined,
+        padding: float | UndefinedType = Undefined,
+        paddingInner: float | UndefinedType = Undefined,
+        paddingOuter: float | UndefinedType = Undefined,
+        range: Sequence[float | str | ExprRef | dict[str, Any]]
+        | str
+        | UndefinedType = Undefined,
+        reverse: bool | UndefinedType = Undefined,
+        round: bool | UndefinedType = Undefined,
+        scheme: str | SchemeParams | SchemeParamsKwds | UndefinedType = Undefined,
+        type: ScaleType_T | UndefinedType = Undefined,
+        zero: bool | UndefinedType = Undefined,
+        zoom: bool | ZoomParams | ZoomParamsKwds | UndefinedType = Undefined,
+    ) -> OffsetDef:
+        """Return a copy with a ``Scale`` scale.
+
+        Args:
+            align (float): The alignment of the steps within the scale range. This value must lie in the range ``[0,1]``. A value of ``0.5`` indicates that the steps should be centered within the range. A value of ``0`` or ``1`` may be used to shift the bands to one side, say to position them adjacent to an axis. __Default value:__ ``0.5``
+            assembly (str | UrlGenomeDefinition | dict[str, Any] | InlineGenomeDefinition): Genome assembly definition for locus scales. This can be: - A string reference to a named assembly (built-in or root-configured). - An inline anonymous assembly that defines either ``contigs`` or ``url``. If undefined, the default genome from the genome store is used.
+            base (float): The logarithm base of the ``log`` scale (default ``10``).
+            bins (Sequence[float]): An array of bin boundaries over the scale domain. If provided, axes and legends will use the bin boundaries to inform the choice of tick marks and text labels.
+            clamp (bool): If ``true``, values that exceed the data domain are clamped to either the minimum or maximum range value __Default value:__ derived from the scale config's ``clamp`` (``true`` by default).
+            constant (float): A constant determining the slope of the symlog function around zero. Only used for ``symlog`` scales. __Default value:__ ``1``
+            domain (ScalarDomain_T | Sequence[ChromosomalLocus | dict[str, Any]] | SelectionDomainRef | dict[str, Any] | ExprRef | Sequence[float | str | bool | ExprRef | dict[str, Any]]): Customized domain values. For quantitative fields, ``domain`` can take the form of a two-element array with minimum and maximum values. Piecewise scales can be created by providing a ``domain`` with more than two entries. For temporal fields, ``domain`` can be a two-element array minimum and maximum values, in the form of either timestamps or the DateTime definition objects. For ordinal and nominal fields, ``domain`` can be an array that lists valid input values. The domain can also be defined by an expression reference that evaluates to the domain array. Array elements may also be expression references.
+            domainMax (float): Sets the maximum value in the scale domain, overriding the ``domain`` property. This property is only intended for use with scales having continuous domains.
+            domainMid (float): Inserts a single mid-point value into a two-element domain. The mid-point value must lie between the domain minimum and maximum values. This property can be useful for setting a midpoint for diverging color scales. The domainMid property is only intended for use with scales supporting continuous, piecewise domains.
+            domainMin (float): Sets the minimum value in the scale domain, overriding the domain property. This property is only intended for use with scales having continuous domains.
+            domainTransition (bool | dict[str, Any]): Controls whether domain updates are applied immediately or with a smooth transition. Set this to ``false`` to apply domain updates immediately. The default is ``true``, except for domains that include ``ExprRef``s, which default to ``false`` unless overridden. __Default value:__ ``true``, except ``false`` for ``ExprRef``-driven domains.
+            exponent (float): The exponent of the ``pow`` scale.
+            interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
+            name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
+            nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
+            padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
+            paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
+            paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
+            range (Sequence[float | str | ExprRef | dict[str, Any]] | str): The range of the scale. One of: - A string indicating a pre-defined named scale range (e.g., example, ``"symbol"``, or ``"diverging"``). - For continuous scales, two-element array indicating minimum and maximum values, or an array with more than two entries for specifying a piecewise scale. Array elements may also be expression references. - For discrete and discretizing scales, an array of desired output values. Array elements may also be expression references. __Notes:__ 1) For color scales you can also specify a color ``scheme`` instead of ``range``. 2) Any directly specified ``range`` for ``x`` and ``y`` channels will be ignored. Range can be customized via the view's corresponding size (``width`` and ``height``).
+            reverse (bool): If true, reverses the order of the scale range. __Default value:__ ``false``.
+            round (bool): If ``true``, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid. __Default value:__ ``false``.
+            scheme (str | SchemeParams | SchemeParamsKwds): A string indicating a color scheme name (e.g., ``"category10"`` or ``"blues"``) or a scheme parameter object. Discrete color schemes may be used with discrete or discretizing scales. Continuous color schemes are intended for use with color scales. For the full list of supported schemes, please refer to the Vega Scheme reference.
+            type (ScaleType_T): The type of scale. Vega-Lite supports the following categories of scale types: 1) **Continuous Scales** -- mapping continuous domains to continuous output ranges (``"linear"``, ``"pow"``, ``"sqrt"``, ``"symlog"``, ``"log"``, ``"time"``, ``"utc"``. 2) **Discrete Scales** -- mapping discrete domains to discrete (``"ordinal"``) or continuous (``"band"`` and ``"point"``) output ranges. 3) **Discretizing Scales** -- mapping continuous domains to discrete output ranges ``"bin-ordinal"``, ``"quantile"``, ``"quantize"`` and ``"threshold"``. __Default value:__ please see the scale type table.
+            zero (bool): If ``true``, ensures that a zero baseline value is included in the scale domain. __Default value:__ ``true`` for x and y channels if the quantitative field is not binned and no custom ``domain`` is provided; ``false`` otherwise. __Note:__ Log, time, and utc scales do not support ``zero``.
+            zoom (bool | ZoomParams | ZoomParamsKwds): If ``true`` and the scale is used on a positional channel, it can bee zoomed and translated interactively.
+        """
+        defined = {
+            "align": align,
+            "assembly": assembly,
+            "base": base,
+            "bins": bins,
+            "clamp": clamp,
+            "constant": constant,
+            "domain": domain,
+            "domainMax": domainMax,
+            "domainMid": domainMid,
+            "domainMin": domainMin,
+            "domainTransition": domainTransition,
+            "exponent": exponent,
+            "interpolate": interpolate,
+            "name": name,
+            "nice": nice,
+            "numberingOffset": numberingOffset,
+            "padding": padding,
+            "paddingInner": paddingInner,
+            "paddingOuter": paddingOuter,
+            "range": range,
+            "reverse": reverse,
+            "round": round,
+            "scheme": scheme,
+            "type": type,
+            "zero": zero,
+            "zoom": zoom,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("scale", value, **defined)
+
+    def title(self, value: str | None) -> OffsetDef:
+        """Return a copy with ``title`` updated."""
+        return self._with_property("title", value)
+
+    def type(self, value: Type_T) -> OffsetDef:
+        """Return a copy with ``type`` updated."""
+        return self._with_property("type", value)
+
+    def value(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> OffsetDef:
         """Return a copy with a ``ExprRef`` value.
 
         Args:
@@ -27983,9 +29083,11 @@ class PointConfig(GenomeSpySchema):
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -28017,8 +29119,10 @@ class PointConfig(GenomeSpySchema):
             style=style,
             tooltip=tooltip,
             x=x,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -28408,9 +29512,41 @@ class PointConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x", value, **defined)
 
-    def xOffset(self, value: float) -> PointConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> PointConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> PointConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -28430,9 +29566,41 @@ class PointConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y", value, **defined)
 
-    def yOffset(self, value: float) -> PointConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> PointConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> PointConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class PointProps(GenomeSpySchema):
@@ -28488,9 +29656,11 @@ class PointProps(GenomeSpySchema):
         | UndefinedType = Undefined,
         type: Literal["point"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -28523,8 +29693,10 @@ class PointProps(GenomeSpySchema):
             tooltip=tooltip,
             type=type,
             x=x,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -28918,9 +30090,41 @@ class PointProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x", value, **defined)
 
-    def xOffset(self, value: float) -> PointProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> PointProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> PointProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -28940,9 +30144,41 @@ class PointProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y", value, **defined)
 
-    def yOffset(self, value: float) -> PointProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> PointProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> PointProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class PointSelectionConfig(GenomeSpySchema):
@@ -29070,6 +30306,7 @@ class Position2Def(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -29148,6 +30385,7 @@ class Position2Def(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -29224,6 +30462,7 @@ class Position2Def(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -29378,7 +30617,7 @@ class Position2Def(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -29514,6 +30753,7 @@ class PositionDatumDef(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -29592,6 +30832,7 @@ class PositionDatumDef(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -29668,6 +30909,7 @@ class PositionDatumDef(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -29802,7 +31044,7 @@ class PositionDatumDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -29932,6 +31174,7 @@ class PositionDef(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -30010,6 +31253,7 @@ class PositionDef(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -30086,6 +31330,7 @@ class PositionDef(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -30240,7 +31485,7 @@ class PositionDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -30372,6 +31617,7 @@ class PositionExprDef(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -30450,6 +31696,7 @@ class PositionExprDef(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -30526,6 +31773,7 @@ class PositionExprDef(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -30666,6 +31914,7 @@ class PositionFieldDef(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -30744,6 +31993,7 @@ class PositionFieldDef(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -30820,6 +32070,7 @@ class PositionFieldDef(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -30954,7 +32205,7 @@ class PositionFieldDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -31231,10 +32482,12 @@ class RectConfig(GenomeSpySchema):
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -31269,9 +32522,11 @@ class RectConfig(GenomeSpySchema):
             tooltip=tooltip,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -31743,9 +32998,41 @@ class RectConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> RectConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RectConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RectConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -31783,9 +33070,41 @@ class RectConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> RectConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RectConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RectConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class RectProps(GenomeSpySchema):
@@ -31862,10 +33181,12 @@ class RectProps(GenomeSpySchema):
         type: Literal["rect"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -31901,9 +33222,11 @@ class RectProps(GenomeSpySchema):
             type=type,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -32379,9 +33702,41 @@ class RectProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> RectProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RectProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RectProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -32419,9 +33774,41 @@ class RectProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> RectProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RectProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RectProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class RegexExtractParams(GenomeSpySchema):
@@ -32576,10 +33963,12 @@ class RuleConfig(GenomeSpySchema):
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -32599,9 +33988,11 @@ class RuleConfig(GenomeSpySchema):
             tooltip=tooltip,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -32789,9 +34180,41 @@ class RuleConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> RuleConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RuleConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RuleConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -32829,9 +34252,41 @@ class RuleConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> RuleConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RuleConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RuleConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class RuleProps(GenomeSpySchema):
@@ -32874,10 +34329,12 @@ class RuleProps(GenomeSpySchema):
         type: Literal["rule"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -32898,9 +34355,11 @@ class RuleProps(GenomeSpySchema):
             type=type,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -33092,9 +34551,41 @@ class RuleProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> RuleProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RuleProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RuleProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -33132,9 +34623,41 @@ class RuleProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> RuleProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RuleProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> RuleProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class RulerChannelValue(GenomeSpySchema):
@@ -34437,6 +35960,7 @@ class SecondaryChromPosDef(GenomeSpySchema):
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -34515,6 +36039,7 @@ class SecondaryChromPosDef(GenomeSpySchema):
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -34591,6 +36116,7 @@ class SecondaryChromPosDef(GenomeSpySchema):
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -34926,10 +36452,12 @@ class SeparatorProps(GenomeSpySchema):
         type: Literal["rule"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         zindex: float | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
@@ -34952,9 +36480,11 @@ class SeparatorProps(GenomeSpySchema):
             type=type,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
             zindex=zindex,
         )
@@ -35151,9 +36681,41 @@ class SeparatorProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> SeparatorProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> SeparatorProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> SeparatorProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -35191,9 +36753,41 @@ class SeparatorProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> SeparatorProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> SeparatorProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> SeparatorProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
     def zindex(self, value: float) -> SeparatorProps:
         """Return a copy with ``zindex`` updated."""
@@ -35596,7 +37190,7 @@ class ShapeDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -35881,12 +37475,17 @@ class Step(GenomeSpySchema):
 
     def __init__(
         self,
+        for_: Literal["position", "offset"] | UndefinedType = Undefined,
         step: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
-        super().__init__(step=step)
+        super().__init__(step=step, **{"for": for_})
         if kwds:
             self._kwds.update(kwds)
+
+    def for_(self, value: Literal["position", "offset"]) -> Step:
+        """Return a copy with ``for`` updated."""
+        return self._with_property("for", value)
 
     def step(
         self,
@@ -36022,7 +37621,7 @@ class StringDatumDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -36217,6 +37816,7 @@ class StyleConfig(GenomeSpySchema):
         domainWidth: float | UndefinedType = Undefined,
         dx: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         dy: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         fill: str | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         fillGradientStrength: float
         | ExprRef
@@ -36413,10 +38013,12 @@ class StyleConfig(GenomeSpySchema):
         viewportEdgeFadeWidthTop: float | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         zindex: float | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
@@ -36478,6 +38080,7 @@ class StyleConfig(GenomeSpySchema):
             domainWidth=domainWidth,
             dx=dx,
             dy=dy,
+            extraValues=extraValues,
             fill=fill,
             fillGradientStrength=fillGradientStrength,
             fillOpacity=fillOpacity,
@@ -36612,9 +38215,11 @@ class StyleConfig(GenomeSpySchema):
             viewportEdgeFadeWidthTop=viewportEdgeFadeWidthTop,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
             zindex=zindex,
         )
@@ -36999,6 +38604,10 @@ class StyleConfig(GenomeSpySchema):
     def dy(self, value: float | ExprRef | dict[str, Any]) -> StyleConfig:
         """Return a copy with ``dy`` updated."""
         return self._with_property("dy", value)
+
+    def extraValues(self, value: Sequence[float]) -> StyleConfig:
+        """Return a copy with ``extraValues`` updated."""
+        return self._with_property("extraValues", value)
 
     def fill(
         self,
@@ -38280,9 +39889,41 @@ class StyleConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> StyleConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> StyleConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> StyleConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -38320,9 +39961,41 @@ class StyleConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> StyleConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> StyleConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> StyleConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
     def zindex(self, value: float) -> StyleConfig:
         """Return a copy with ``zindex`` updated."""
@@ -38528,10 +40201,12 @@ class TextConfig(GenomeSpySchema):
         viewportEdgeFadeWidthTop: float | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -38571,9 +40246,11 @@ class TextConfig(GenomeSpySchema):
             viewportEdgeFadeWidthTop=viewportEdgeFadeWidthTop,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -38925,9 +40602,41 @@ class TextConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> TextConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TextConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TextConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -38965,9 +40674,41 @@ class TextConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> TextConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TextConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TextConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class TextDef(GenomeSpySchema):
@@ -39105,7 +40846,7 @@ class TextDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -39230,10 +40971,12 @@ class TextProps(GenomeSpySchema):
         viewportEdgeFadeWidthTop: float | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -39274,9 +41017,11 @@ class TextProps(GenomeSpySchema):
             viewportEdgeFadeWidthTop=viewportEdgeFadeWidthTop,
             x=x,
             x2=x2,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
             y2=y2,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -39632,9 +41377,41 @@ class TextProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x2", value, **defined)
 
-    def xOffset(self, value: float) -> TextProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TextProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TextProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -39672,9 +41449,41 @@ class TextProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y2", value, **defined)
 
-    def yOffset(self, value: float) -> TextProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TextProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TextProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class TickConfig(GenomeSpySchema):
@@ -39716,9 +41525,11 @@ class TickConfig(GenomeSpySchema):
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -39738,8 +41549,10 @@ class TickConfig(GenomeSpySchema):
             thickness=thickness,
             tooltip=tooltip,
             x=x,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -39899,9 +41712,41 @@ class TickConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x", value, **defined)
 
-    def xOffset(self, value: float) -> TickConfig:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TickConfig:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TickConfig:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -39921,9 +41766,41 @@ class TickConfig(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y", value, **defined)
 
-    def yOffset(self, value: float) -> TickConfig:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TickConfig:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TickConfig:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class TickProps(GenomeSpySchema):
@@ -39966,9 +41843,11 @@ class TickProps(GenomeSpySchema):
         | UndefinedType = Undefined,
         type: Literal["tick"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         **kwds: Any,
     ) -> None:
         super().__init__(
@@ -39989,8 +41868,10 @@ class TickProps(GenomeSpySchema):
             tooltip=tooltip,
             type=type,
             x=x,
+            x2Offset=x2Offset,
             xOffset=xOffset,
             y=y,
+            y2Offset=y2Offset,
             yOffset=yOffset,
         )
         if kwds:
@@ -40154,9 +42035,41 @@ class TickProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("x", value, **defined)
 
-    def xOffset(self, value: float) -> TickProps:
-        """Return a copy with ``xOffset`` updated."""
-        return self._with_property("xOffset", value)
+    def x2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TickProps:
+        """Return a copy with a ``ExprRef`` x2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("x2Offset", value, **defined)
+
+    def xOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TickProps:
+        """Return a copy with a ``ExprRef`` xOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("xOffset", value, **defined)
 
     def y(
         self,
@@ -40176,9 +42089,41 @@ class TickProps(GenomeSpySchema):
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("y", value, **defined)
 
-    def yOffset(self, value: float) -> TickProps:
-        """Return a copy with ``yOffset`` updated."""
-        return self._with_property("yOffset", value)
+    def y2Offset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TickProps:
+        """Return a copy with a ``ExprRef`` y2Offset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("y2Offset", value, **defined)
+
+    def yOffset(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TickProps:
+        """Return a copy with a ``ExprRef`` yOffset.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("yOffset", value, **defined)
 
 
 class Title(GenomeSpySchema):
@@ -40879,7 +42824,7 @@ class TooltipDef(GenomeSpySchema):
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -40981,6 +42926,7 @@ class TransformParams(GenomeSpySchema):
         end: Field_T | UndefinedType = Undefined,
         exons: Field_T | UndefinedType = Undefined,
         expr: str | UndefinedType = Undefined,
+        extent: Sequence[float] | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         field: Field_T | UndefinedType = Undefined,
         fields: Sequence[Field_T | None] | UndefinedType = Undefined,
         font: str | UndefinedType = Undefined,
@@ -41003,6 +42949,7 @@ class TransformParams(GenomeSpySchema):
         labelOffset: float | UndefinedType = Undefined,
         labelWidth: Field_T | UndefinedType = Undefined,
         lane: Field_T | UndefinedType = Undefined,
+        length: float | Field_T | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         limit: float | UndefinedType = Undefined,
         md: Field_T | UndefinedType = Undefined,
         membership: Field_T | UndefinedType = Undefined,
@@ -41014,6 +42961,7 @@ class TransformParams(GenomeSpySchema):
         params: Sequence[float | None] | UndefinedType = Undefined,
         pos: Field_T | Sequence[Field_T] | UndefinedType = Undefined,
         pos2: Field_T | UndefinedType = Undefined,
+        positionFactor: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         preference: Field_T | UndefinedType = Undefined,
         preferredOrder: Sequence[str]
         | Sequence[float]
@@ -41069,6 +43017,7 @@ class TransformParams(GenomeSpySchema):
             end=end,
             exons=exons,
             expr=expr,
+            extent=extent,
             field=field,
             fields=fields,
             font=font,
@@ -41083,6 +43032,7 @@ class TransformParams(GenomeSpySchema):
             labelOffset=labelOffset,
             labelWidth=labelWidth,
             lane=lane,
+            length=length,
             limit=limit,
             md=md,
             membership=membership,
@@ -41093,6 +43043,7 @@ class TransformParams(GenomeSpySchema):
             params=params,
             pos=pos,
             pos2=pos2,
+            positionFactor=positionFactor,
             preference=preference,
             preferredOrder=preferredOrder,
             quality=quality,
@@ -41223,6 +43174,24 @@ class TransformParams(GenomeSpySchema):
         """Return a copy with ``expr`` updated."""
         return self._with_property("expr", value)
 
+    def extent(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TransformParams:
+        """Return a copy with a ``ExprRef`` extent.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("extent", value, **defined)
+
     def field(self, value: Field_T) -> TransformParams:
         """Return a copy with ``field`` updated."""
         return self._with_property("field", value)
@@ -41292,6 +43261,12 @@ class TransformParams(GenomeSpySchema):
         """Return a copy with ``lane`` updated."""
         return self._with_property("lane", value)
 
+    def length(
+        self, value: float | Field_T | ExprRef | dict[str, Any]
+    ) -> TransformParams:
+        """Return a copy with ``length`` updated."""
+        return self._with_property("length", value)
+
     def limit(self, value: float) -> TransformParams:
         """Return a copy with ``limit`` updated."""
         return self._with_property("limit", value)
@@ -41333,6 +43308,24 @@ class TransformParams(GenomeSpySchema):
     def pos2(self, value: Field_T) -> TransformParams:
         """Return a copy with ``pos2`` updated."""
         return self._with_property("pos2", value)
+
+    def positionFactor(
+        self,
+        value: ExprRef | dict[str, Any] | None | object = Undefined,
+        /,
+        *,
+        expr: str | UndefinedType = Undefined,
+    ) -> TransformParams:
+        """Return a copy with a ``ExprRef`` positionFactor.
+
+        Args:
+            expr (str): The expression string.
+        """
+        defined = {
+            "expr": expr,
+        }
+        defined = {key: item for key, item in defined.items() if item is not Undefined}
+        return self._with_property("positionFactor", value, **defined)
 
     def preference(self, value: Field_T) -> TransformParams:
         """Return a copy with ``preference`` updated."""
@@ -41755,6 +43748,7 @@ class UnitSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -42097,6 +44091,14 @@ class UnitSpec(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -42106,6 +44108,14 @@ class UnitSpec(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
     ) -> UnitSpec:
         """Return a copy with a ``Encoding`` encoding.
 
@@ -42113,8 +44123,8 @@ class UnitSpec(GenomeSpySchema):
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -42123,7 +44133,7 @@ class UnitSpec(GenomeSpySchema):
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -42133,8 +44143,10 @@ class UnitSpec(GenomeSpySchema):
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         defined = {
             "angle": angle,
@@ -42160,8 +44172,10 @@ class UnitSpec(GenomeSpySchema):
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("encoding", value, **defined)
@@ -42380,6 +44394,7 @@ class UnitSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -42563,6 +44578,7 @@ class UrlData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat
         | UndefinedType = Undefined,
@@ -42592,6 +44608,7 @@ class UrlData(GenomeSpySchema):
         | JsonDataFormat
         | BedDataFormat
         | BedpeDataFormat
+        | WigDataFormat
         | VcfDataFormat
         | OtherDataFormat,
     ) -> UrlData:
@@ -42904,6 +44921,7 @@ class VConcatSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -43256,6 +45274,14 @@ class VConcatSpec(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -43265,6 +45291,14 @@ class VConcatSpec(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
     ) -> VConcatSpec:
         """Return a copy with a ``Encoding`` encoding.
 
@@ -43272,8 +45306,8 @@ class VConcatSpec(GenomeSpySchema):
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -43282,7 +45316,7 @@ class VConcatSpec(GenomeSpySchema):
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -43292,8 +45326,10 @@ class VConcatSpec(GenomeSpySchema):
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         defined = {
             "angle": angle,
@@ -43319,8 +45355,10 @@ class VConcatSpec(GenomeSpySchema):
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("encoding", value, **defined)
@@ -43452,10 +45490,12 @@ class VConcatSpec(GenomeSpySchema):
         type: Literal["rule"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         zindex: float | UndefinedType = Undefined,
     ) -> VConcatSpec:
         """Return a copy with a ``SeparatorProps`` separator.
@@ -43479,10 +45519,12 @@ class VConcatSpec(GenomeSpySchema):
             type (Literal['rule']): Schema-defined ``type`` property.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
             zindex (float): Z-order of the separator relative to the view content. Values greater than ``0`` render after the view marks. Values less than or equal to ``0`` render before the marks. __Default value:__ ``0``
         """
         defined = {
@@ -43504,9 +45546,11 @@ class VConcatSpec(GenomeSpySchema):
             "type": type,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
             "zindex": zindex,
         }
@@ -43621,6 +45665,7 @@ class VConcatSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -44589,14 +46634,17 @@ class ViewConfig(GenomeSpySchema):
         value: Step | StepKwds | None | object = Undefined,
         /,
         *,
+        for_: Literal["position", "offset"] | UndefinedType = Undefined,
         step: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> ViewConfig:
         """Return a copy with a ``Step`` discreteHeight.
 
         Args:
+            for\\_ (Literal['position', 'offset']): Selects which discrete scale the step describes when a positional scale has a nested offset scale. ``"offset"`` sizes each subgroup step; ``"position"`` sizes each primary category step. __Default value:__ ``"offset"`` when a discrete nested offset scale is present, otherwise ``"position"``.
             step (float | ExprRef | dict[str, Any]): Step size in pixels.
         """
         defined = {
+            "for": for_,
             "step": step,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -44607,14 +46655,17 @@ class ViewConfig(GenomeSpySchema):
         value: Step | StepKwds | None | object = Undefined,
         /,
         *,
+        for_: Literal["position", "offset"] | UndefinedType = Undefined,
         step: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> ViewConfig:
         """Return a copy with a ``Step`` discreteWidth.
 
         Args:
+            for\\_ (Literal['position', 'offset']): Selects which discrete scale the step describes when a positional scale has a nested offset scale. ``"offset"`` sizes each subgroup step; ``"position"`` sizes each primary category step. __Default value:__ ``"offset"`` when a discrete nested offset scale is present, otherwise ``"position"``.
             step (float | ExprRef | dict[str, Any]): Step size in pixels.
         """
         defined = {
+            "for": for_,
             "step": step,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -44914,6 +46965,7 @@ class ViewSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -45296,6 +47348,14 @@ class ViewSpec(GenomeSpySchema):
         uniqueId: FieldDefWithoutScale | dict[str, Any] | UndefinedType = Undefined,
         x: dict[str, Any] | None | UndefinedType = Undefined,
         x2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        xOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
         y: PositionFieldDef
         | dict[str, Any]
         | ChromPosDef
@@ -45305,6 +47365,14 @@ class ViewSpec(GenomeSpySchema):
         | None
         | UndefinedType = Undefined,
         y2: Position2Def | dict[str, Any] | None | UndefinedType = Undefined,
+        yOffset: FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber
+        | dict[str, Any]
+        | FieldOrDatumDefWithConditionScaleDatumDefNumber
+        | MarkPropExprDefType
+        | ValueDefWithConditionNumberType
+        | MarkPropExprDef
+        | None
+        | UndefinedType = Undefined,
     ) -> ViewSpec:
         """Return a copy with a ``Encoding`` encoding.
 
@@ -45312,8 +47380,8 @@ class ViewSpec(GenomeSpySchema):
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -45322,7 +47390,7 @@ class ViewSpec(GenomeSpySchema):
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -45332,8 +47400,10 @@ class ViewSpec(GenomeSpySchema):
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         defined = {
             "angle": angle,
@@ -45359,8 +47429,10 @@ class ViewSpec(GenomeSpySchema):
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("encoding", value, **defined)
@@ -45548,10 +47620,12 @@ class ViewSpec(GenomeSpySchema):
         type: Literal["rule"] | UndefinedType = Undefined,
         x: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | ExprRef | dict[str, Any] | UndefinedType = Undefined,
         zindex: float | UndefinedType = Undefined,
     ) -> ViewSpec:
         """Return a copy with a ``SeparatorProps`` separator.
@@ -45575,10 +47649,12 @@ class ViewSpec(GenomeSpySchema):
             type (Literal['rule']): Schema-defined ``type`` property.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
             zindex (float): Z-order of the separator relative to the view content. Values greater than ``0`` render after the view marks. Values less than or equal to ``0`` render before the marks. __Default value:__ ``0``
         """
         defined = {
@@ -45600,9 +47676,11 @@ class ViewSpec(GenomeSpySchema):
             "type": type,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
             "zindex": zindex,
         }
@@ -45727,6 +47805,7 @@ class ViewSpec(GenomeSpySchema):
             | CoverageParams
             | CoordinateLookupParams
             | CrossParams
+            | Displace1DParams
             | FlattenDelimitedParams
             | FormulaParams
             | LookupParams
@@ -45910,6 +47989,35 @@ class ViewSpec(GenomeSpySchema):
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._with_property("width", value, **defined)
+
+
+class WigDataFormat(GenomeSpySchema):
+    """Generated wrapper for ``WigDataFormat``."""
+
+    _schema = _ROOT_SCHEMA.get("definitions", {}).get("WigDataFormat", {})
+
+    def __init__(
+        self,
+        parse: Parse | ParseKwds | None | UndefinedType = Undefined,
+        type: Literal["wig"] | UndefinedType = Undefined,
+        **kwds: Any,
+    ) -> None:
+        super().__init__(parse=parse, type=type)
+        if kwds:
+            self._kwds.update(kwds)
+
+    def parse(
+        self,
+        value: Parse | ParseKwds | None | object = Undefined,
+        /,
+    ) -> WigDataFormat:
+        """Return a copy with a ``Parse`` parse."""
+        defined: dict[str, Any] = {}
+        return self._with_property("parse", value, **defined)
+
+    def type(self, value: Literal["wig"]) -> WigDataFormat:
+        """Return a copy with ``type`` updated."""
+        return self._with_property("type", value)
 
 
 class WindowOnlyOp(GenomeSpySchema):
@@ -46124,6 +48232,7 @@ __all__ = [
     "DataFormat",
     "DataSource",
     "DirectionDef",
+    "Displace1DParams",
     "DomEventType",
     "DomainValue",
     "DomainValueArray",
@@ -46213,6 +48322,8 @@ __all__ = [
     "NumericMarkPropDef",
     "NumericStopDef",
     "NumericValueDef",
+    "OffsetChannel",
+    "OffsetDef",
     "OtherDataFormat",
     "OverhangConfig",
     "PackLegendLabelsParams",
@@ -46330,6 +48441,7 @@ __all__ = [
     "ViewConfig",
     "ViewOpacityDef",
     "ViewSpec",
+    "WigDataFormat",
     "WindowOnlyOp",
     "WindowOp",
     "WindowParams",

--- a/src/genome_spy/schema/ergonomics.py
+++ b/src/genome_spy/schema/ergonomics.py
@@ -98,6 +98,7 @@ class DatumChannelMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -176,6 +177,7 @@ class DatumChannelMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -252,6 +254,7 @@ class DatumChannelMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -415,7 +418,7 @@ class DatumChannelMethodMixin:
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.
@@ -542,6 +545,7 @@ class LocusChannelMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -620,6 +624,7 @@ class LocusChannelMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -696,6 +701,7 @@ class LocusChannelMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -810,7 +816,7 @@ class LocusChannelMethodMixin:
             interpolate (ScaleInterpolate_T | ScaleInterpolateParams | ScaleInterpolateParamsKwds): The interpolation method for range values. By default, a general interpolator for numbers, dates, strings and colors (in HCL space) is used. For color ranges, this property allows interpolation in alternative color spaces. Legal values include ``rgb``, ``hsl``, ``hsl-long``, ``lab``, ``hcl``, ``hcl-long``, ``cubehelix`` and ``cubehelix-long`` ('-long' variants use longer paths in polar coordinate spaces). If object-valued, this property accepts an object with a string-valued type property and an optional numeric gamma property applicable to rgb and cubehelix interpolators. For more, see the d3-interpolate documentation. __Default value:__ ``hcl``
             name (str): The name of the scale. Names are optional but allow the scales to be referenced and found with the API.
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
             paddingInner (float): The inner padding (spacing) within each band step of band scales, as a fraction of the step size. This value must lie in the range [0,1]. For point scale, this property is invalid as point scales do not have internal band widths (only step sizes between bands). __Default value:__ derived from the scale config's ``bandPaddingInner``.
             paddingOuter (float): The outer padding (spacing) at the ends of the range of band and point scales, as a fraction of the step size. This value must lie in the range [0,1]. __Default value:__ derived from the scale config's ``bandPaddingOuter`` for band scales and ``pointPadding`` for point scales. By default, Vega-Lite sets outer padding such that width/height = number of unique values * step.

--- a/src/genome_spy/schema/genome-spy-schema.json
+++ b/src/genome_spy/schema/genome-spy-schema.json
@@ -439,9 +439,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -465,9 +483,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "type": "object"
@@ -805,9 +841,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -831,9 +885,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "required": [
@@ -910,6 +982,13 @@
         "domainWidth": {
           "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
           "type": "number"
+        },
+        "extraValues": {
+          "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
         },
         "format": {
           "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -1285,6 +1364,13 @@
         "domainWidth": {
           "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
           "type": "number"
+        },
+        "extraValues": {
+          "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
         },
         "format": {
           "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -2124,6 +2210,9 @@
           "$ref": "#/definitions/PositionalChannel"
         },
         {
+          "$ref": "#/definitions/OffsetChannel"
+        },
+        {
           "const": "color",
           "type": "string"
         },
@@ -2501,6 +2590,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -2876,6 +2972,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -3243,6 +3346,12 @@
             },
             "strokeWidth": {
               "$ref": "#/definitions/Legend"
+            },
+            "xOffset": {
+              "$ref": "#/definitions/Legend"
+            },
+            "yOffset": {
+              "$ref": "#/definitions/Legend"
             }
           },
           "type": "object"
@@ -3345,10 +3454,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -3429,10 +3544,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -3513,10 +3634,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -3574,10 +3701,16 @@
             "x2": {
               "$ref": "#/definitions/Scale"
             },
+            "xOffset": {
+              "$ref": "#/definitions/Scale"
+            },
             "y": {
               "$ref": "#/definitions/Scale"
             },
             "y2": {
+              "$ref": "#/definitions/Scale"
+            },
+            "yOffset": {
               "$ref": "#/definitions/Scale"
             }
           },
@@ -4427,6 +4560,13 @@
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
                     },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
+                    },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                       "type": "string"
@@ -4801,6 +4941,13 @@
                     "domainWidth": {
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
+                    },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
                     },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -5167,6 +5314,12 @@
                 },
                 "strokeWidth": {
                   "$ref": "#/definitions/Legend"
+                },
+                "xOffset": {
+                  "$ref": "#/definitions/Legend"
+                },
+                "yOffset": {
+                  "$ref": "#/definitions/Legend"
                 }
               },
               "type": "object"
@@ -5284,10 +5437,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -5368,10 +5527,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -5452,10 +5617,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -5513,10 +5684,16 @@
                 "x2": {
                   "$ref": "#/definitions/Scale"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/Scale"
+                },
                 "y": {
                   "$ref": "#/definitions/Scale"
                 },
                 "y2": {
+                  "$ref": "#/definitions/Scale"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/Scale"
                 }
               },
@@ -5785,6 +5962,13 @@
                     "domainWidth": {
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
+                    },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
                     },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -6160,6 +6344,13 @@
                     "domainWidth": {
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
+                    },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
                     },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -6545,6 +6736,12 @@
                 },
                 "strokeWidth": {
                   "$ref": "#/definitions/Legend"
+                },
+                "xOffset": {
+                  "$ref": "#/definitions/Legend"
+                },
+                "yOffset": {
+                  "$ref": "#/definitions/Legend"
                 }
               },
               "type": "object"
@@ -6651,10 +6848,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -6735,10 +6938,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -6819,10 +7028,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -6880,10 +7095,16 @@
                 "x2": {
                   "$ref": "#/definitions/Scale"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/Scale"
+                },
                 "y": {
                   "$ref": "#/definitions/Scale"
                 },
                 "y2": {
+                  "$ref": "#/definitions/Scale"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/Scale"
                 }
               },
@@ -7151,6 +7372,13 @@
                     "domainWidth": {
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
+                    },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
                     },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -7526,6 +7754,13 @@
                     "domainWidth": {
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
+                    },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
                     },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -7892,6 +8127,12 @@
                 },
                 "strokeWidth": {
                   "$ref": "#/definitions/Legend"
+                },
+                "xOffset": {
+                  "$ref": "#/definitions/Legend"
+                },
+                "yOffset": {
+                  "$ref": "#/definitions/Legend"
                 }
               },
               "type": "object"
@@ -8017,10 +8258,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -8101,10 +8348,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -8185,10 +8438,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -8246,10 +8505,16 @@
                 "x2": {
                   "$ref": "#/definitions/Scale"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/Scale"
+                },
                 "y": {
                   "$ref": "#/definitions/Scale"
                 },
                 "y2": {
+                  "$ref": "#/definitions/Scale"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/Scale"
                 }
               },
@@ -8523,6 +8788,13 @@
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
                     },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
+                    },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                       "type": "string"
@@ -8898,6 +9170,13 @@
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
                     },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
+                    },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                       "type": "string"
@@ -9263,6 +9542,12 @@
                 },
                 "strokeWidth": {
                   "$ref": "#/definitions/Legend"
+                },
+                "xOffset": {
+                  "$ref": "#/definitions/Legend"
+                },
+                "yOffset": {
+                  "$ref": "#/definitions/Legend"
                 }
               },
               "type": "object"
@@ -9365,10 +9650,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -9449,10 +9740,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -9533,10 +9830,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -9594,10 +9897,16 @@
                 "x2": {
                   "$ref": "#/definitions/Scale"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/Scale"
+                },
                 "y": {
                   "$ref": "#/definitions/Scale"
                 },
                 "y2": {
+                  "$ref": "#/definitions/Scale"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/Scale"
                 }
               },
@@ -9891,6 +10200,13 @@
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
                     },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
+                    },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                       "type": "string"
@@ -10265,6 +10581,13 @@
                     "domainWidth": {
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
+                    },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
                     },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -10644,6 +10967,12 @@
                 },
                 "strokeWidth": {
                   "$ref": "#/definitions/Legend"
+                },
+                "xOffset": {
+                  "$ref": "#/definitions/Legend"
+                },
+                "yOffset": {
+                  "$ref": "#/definitions/Legend"
                 }
               },
               "type": "object"
@@ -10746,10 +11075,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -10830,10 +11165,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -10914,10 +11255,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -10975,10 +11322,16 @@
                 "x2": {
                   "$ref": "#/definitions/Scale"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/Scale"
+                },
                 "y": {
                   "$ref": "#/definitions/Scale"
                 },
                 "y2": {
+                  "$ref": "#/definitions/Scale"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/Scale"
                 }
               },
@@ -11258,6 +11611,13 @@
                     "domainWidth": {
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
+                    },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
                     },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -11633,6 +11993,13 @@
                     "domainWidth": {
                       "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                       "type": "number"
+                    },
+                    "extraValues": {
+                      "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                      "items": {
+                        "type": "number"
+                      },
+                      "type": "array"
                     },
                     "format": {
                       "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
@@ -12016,6 +12383,12 @@
                 },
                 "strokeWidth": {
                   "$ref": "#/definitions/Legend"
+                },
+                "xOffset": {
+                  "$ref": "#/definitions/Legend"
+                },
+                "yOffset": {
+                  "$ref": "#/definitions/Legend"
                 }
               },
               "type": "object"
@@ -12118,10 +12491,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -12202,10 +12581,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -12286,10 +12671,16 @@
                     "x2": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
+                    "xOffset": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
                     "y": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     },
                     "y2": {
+                      "$ref": "#/definitions/ResolutionBehavior"
+                    },
+                    "yOffset": {
                       "$ref": "#/definitions/ResolutionBehavior"
                     }
                   },
@@ -12347,10 +12738,16 @@
                 "x2": {
                   "$ref": "#/definitions/Scale"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/Scale"
+                },
                 "y": {
                   "$ref": "#/definitions/Scale"
                 },
                 "y2": {
+                  "$ref": "#/definitions/Scale"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/Scale"
                 }
               },
@@ -12650,6 +13047,9 @@
           "$ref": "#/definitions/BedpeDataFormat"
         },
         {
+          "$ref": "#/definitions/WigDataFormat"
+        },
+        {
           "$ref": "#/definitions/VcfDataFormat"
         },
         {
@@ -12791,6 +13191,75 @@
           "$ref": "#/definitions/ValueDef%3CArrowDirection%3E"
         }
       ]
+    },
+    "Displace1DParams": {
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "description": "The output field for signed displacement.\n\n__Default value:__ `\"displacement\"`",
+          "type": "string"
+        },
+        "description": {
+          "description": "A description of the transform step. Can be used for documentation and agent context.",
+          "type": "string"
+        },
+        "extent": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "number"
+              },
+              "maxItems": 2,
+              "minItems": 2,
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Preferred outer bounds for the placed collision intervals, expressed in the original `pos` coordinate system. The bounds are multiplied by `positionFactor` together with the item positions. When all items cannot fit, they remain non-overlapping and extend beyond the bounds by the minimum necessary amount. An expression can update the bounds reactively."
+        },
+        "length": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/Field"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "The full collision length, including any desired spacing, or a field containing that length. The value uses the same units as the scaled positions and output displacement. An expression provides a reactive scalar length shared by all rows."
+        },
+        "pos": {
+          "$ref": "#/definitions/Field",
+          "description": "The field containing the original position. Input rows must be ordered by ascending `pos * positionFactor`."
+        },
+        "positionFactor": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "A multiplier applied to `pos` before placement. An expression can convert position units to logical pixels and react to zoom or layout changes. Use an ascending `pos` sort for a positive factor and a descending sort for a negative factor. Place a `collect` transform before this transform to buffer input for expression-driven updates.\n\n__Default value:__ `1`"
+        },
+        "type": {
+          "const": "displace1d",
+          "description": "The type of the transform to be applied",
+          "type": "string"
+        }
+      },
+      "required": [
+        "length",
+        "pos",
+        "type"
+      ],
+      "type": "object"
     },
     "DomEventType": {
       "anyOf": [
@@ -12948,7 +13417,9 @@
             {
               "$ref": "#/definitions/MarkPropExprDef"
             }
-          ]
+          ],
+          "deprecated": "Use `xOffset` instead.",
+          "description": "Legacy horizontal pixel offset for point marks."
         },
         "dy": {
           "anyOf": [
@@ -12958,7 +13429,9 @@
             {
               "$ref": "#/definitions/MarkPropExprDef"
             }
-          ]
+          ],
+          "deprecated": "Use `yOffset` instead.",
+          "description": "Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from `yOffset`."
         },
         "facetIndex": {
           "$ref": "#/definitions/FieldDefWithoutScale",
@@ -13014,7 +13487,7 @@
         },
         "shape": {
           "$ref": "#/definitions/ShapeDef",
-          "description": "Shape of the mark.\n\nFor `point` marks the supported values include:\n- plotting shapes: `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, or `\"triangle-left\"`.\n- centered directional shape `\"triangle\"`"
+          "description": "Shape of the mark.\n\nFor `point` marks the supported values include:\n- plotting shapes: `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, or `\"triangle-left\"`.\n- stroke-only `\"x\"` and `\"+\"` shapes, whose line thickness is controlled by `strokeWidth`\n- centered directional shape `\"triangle\"`"
         },
         "size": {
           "$ref": "#/definitions/NumericMarkPropDef",
@@ -13369,6 +13842,17 @@
           ],
           "description": "X2 coordinates of the marks.\n\nThe `value` of this channel can be a number between zero and one."
         },
+        "xOffset": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OffsetDef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Horizontal offset from the encoded x position, in logical pixels."
+        },
         "y": {
           "anyOf": [
             {
@@ -13390,6 +13874,17 @@
             }
           ],
           "description": "Y2 coordinates of the marks.\n\nThe `value` of this channel can be a number between zero and one."
+        },
+        "yOffset": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OffsetDef"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Vertical offset from the encoded y position, in logical pixels."
         }
       },
       "type": "object"
@@ -14442,6 +14937,13 @@
           "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
           "type": "number"
         },
+        "extraValues": {
+          "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
         "format": {
           "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
           "type": "string"
@@ -15046,6 +15548,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -15421,6 +15930,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -15784,6 +16300,12 @@
             },
             "strokeWidth": {
               "$ref": "#/definitions/Legend"
+            },
+            "xOffset": {
+              "$ref": "#/definitions/Legend"
+            },
+            "yOffset": {
+              "$ref": "#/definitions/Legend"
             }
           },
           "type": "object"
@@ -15886,10 +16408,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -15970,10 +16498,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -16054,10 +16588,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -16115,10 +16655,16 @@
             "x2": {
               "$ref": "#/definitions/Scale"
             },
+            "xOffset": {
+              "$ref": "#/definitions/Scale"
+            },
             "y": {
               "$ref": "#/definitions/Scale"
             },
             "y2": {
+              "$ref": "#/definitions/Scale"
+            },
+            "yOffset": {
               "$ref": "#/definitions/Scale"
             }
           },
@@ -16776,6 +17322,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -17151,6 +17704,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -17520,6 +18080,12 @@
             },
             "strokeWidth": {
               "$ref": "#/definitions/Legend"
+            },
+            "xOffset": {
+              "$ref": "#/definitions/Legend"
+            },
+            "yOffset": {
+              "$ref": "#/definitions/Legend"
             }
           },
           "type": "object"
@@ -17626,10 +18192,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -17710,10 +18282,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -17794,10 +18372,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -17855,10 +18439,16 @@
             "x2": {
               "$ref": "#/definitions/Scale"
             },
+            "xOffset": {
+              "$ref": "#/definitions/Scale"
+            },
             "y": {
               "$ref": "#/definitions/Scale"
             },
             "y2": {
+              "$ref": "#/definitions/Scale"
+            },
+            "yOffset": {
               "$ref": "#/definitions/Scale"
             }
           },
@@ -18822,9 +19412,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -18848,9 +19456,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "type": "object"
@@ -19127,9 +19753,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -19153,9 +19797,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "required": [
@@ -19372,9 +20034,27 @@
           ],
           "description": "Position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -19387,9 +20067,27 @@
           ],
           "description": "Position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "type": "object"
@@ -19908,6 +20606,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -20283,6 +20988,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -20633,6 +21345,12 @@
             },
             "strokeWidth": {
               "$ref": "#/definitions/Legend"
+            },
+            "xOffset": {
+              "$ref": "#/definitions/Legend"
+            },
+            "yOffset": {
+              "$ref": "#/definitions/Legend"
             }
           },
           "type": "object"
@@ -20758,10 +21476,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -20842,10 +21566,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -20926,10 +21656,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -20987,10 +21723,16 @@
             "x2": {
               "$ref": "#/definitions/Scale"
             },
+            "xOffset": {
+              "$ref": "#/definitions/Scale"
+            },
             "y": {
               "$ref": "#/definitions/Scale"
             },
             "y2": {
+              "$ref": "#/definitions/Scale"
+            },
+            "yOffset": {
               "$ref": "#/definitions/Scale"
             }
           },
@@ -21173,6 +21915,24 @@
     },
     "NumericValueDef": {
       "$ref": "#/definitions/ValueDef%3Cnumber%3E"
+    },
+    "OffsetChannel": {
+      "enum": [
+        "xOffset",
+        "yOffset"
+      ],
+      "type": "string"
+    },
+    "OffsetDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/NumericMarkPropDef"
+        },
+        {
+          "$ref": "#/definitions/MarkPropExprDef"
+        }
+      ],
+      "description": "A pixel-valued offset of a primary positional channel."
     },
     "OtherDataFormat": {
       "additionalProperties": false,
@@ -21550,6 +22310,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
+          "deprecated": "Use `xOffset` instead.",
           "description": "Horizontal offset in pixels.\n\n**Default value:** `0`"
         },
         "dy": {
@@ -21561,6 +22322,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
+          "deprecated": "Use `yOffset` instead. Note that positive `yOffset` values\nmove down, while positive `dy` values move up.",
           "description": "Vertical offset in pixels.\n\n**Default value:** `0`"
         },
         "fill": {
@@ -21676,7 +22438,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "One of `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, `\"triangle-left\"`, `\"tick-up\"`, `\"tick-down\"`, `\"tick-right\"`, or `\"tick-left\"`\n\n**Default value:** `\"circle\"`"
+          "description": "One of `\"circle\"`, `\"square\"`, `\"cross\"`, `\"x\"`, `\"+\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, `\"triangle-left\"`, `\"tick-up\"`, `\"tick-down\"`, `\"tick-right\"`, or `\"tick-left\"`. The `\"x\"` and `\"+\"` shapes are stroke-only and use `strokeWidth` for their line thickness.\n\n**Default value:** `\"circle\"`"
         },
         "size": {
           "anyOf": [
@@ -21751,9 +22513,27 @@
           ],
           "description": "Position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -21766,9 +22546,27 @@
           ],
           "description": "Position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "type": "object"
@@ -21858,6 +22656,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
+          "deprecated": "Use `xOffset` instead.",
           "description": "Horizontal offset in pixels.\n\n**Default value:** `0`"
         },
         "dy": {
@@ -21869,6 +22668,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
+          "deprecated": "Use `yOffset` instead. Note that positive `yOffset` values\nmove down, while positive `dy` values move up.",
           "description": "Vertical offset in pixels.\n\n**Default value:** `0`"
         },
         "fill": {
@@ -21984,7 +22784,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "One of `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, `\"triangle-left\"`, `\"tick-up\"`, `\"tick-down\"`, `\"tick-right\"`, or `\"tick-left\"`\n\n**Default value:** `\"circle\"`"
+          "description": "One of `\"circle\"`, `\"square\"`, `\"cross\"`, `\"x\"`, `\"+\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, `\"triangle-left\"`, `\"tick-up\"`, `\"tick-down\"`, `\"tick-right\"`, or `\"tick-left\"`. The `\"x\"` and `\"+\"` shapes are stroke-only and use `strokeWidth` for their line thickness.\n\n**Default value:** `\"circle\"`"
         },
         "size": {
           "anyOf": [
@@ -22063,9 +22863,27 @@
           ],
           "description": "Position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -22078,9 +22896,27 @@
           ],
           "description": "Position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "required": [
@@ -22934,9 +23770,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -22960,9 +23814,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "type": "object"
@@ -23341,9 +24213,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -23367,9 +24257,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "required": [
@@ -23663,9 +24571,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -23689,9 +24615,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "type": "object"
@@ -23873,9 +24817,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -23899,9 +24861,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "required": [
@@ -24357,7 +25337,7 @@
           "description": "Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.\n\nFor quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.\n\n__Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise."
         },
         "numberingOffset": {
-          "description": "The numbering offset used when formatting tick labels on index and locus scales.\n\n__Default value:__ `0`",
+          "description": "The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values.\n\n__Default value:__ `0`",
           "type": "number"
         },
         "padding": {
@@ -24656,7 +25636,7 @@
               "description": "Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.\n\nFor quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.\n\n__Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise."
             },
             "numberingOffset": {
-              "description": "The numbering offset used when formatting tick labels on index and locus scales.\n\n__Default value:__ `0`",
+              "description": "The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values.\n\n__Default value:__ `0`",
               "type": "number"
             },
             "padding": {
@@ -24881,7 +25861,7 @@
               "description": "Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.\n\nFor quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.\n\n__Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise."
             },
             "numberingOffset": {
-              "description": "The numbering offset used when formatting tick labels on index and locus scales.\n\n__Default value:__ `0`",
+              "description": "The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values.\n\n__Default value:__ `0`",
               "type": "number"
             },
             "padding": {
@@ -25126,7 +26106,7 @@
               "description": "Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.\n\nFor quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.\n\n__Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise."
             },
             "numberingOffset": {
-              "description": "The numbering offset used when formatting tick labels on index and locus scales.\n\n__Default value:__ `0`",
+              "description": "The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values.\n\n__Default value:__ `0`",
               "type": "number"
             },
             "padding": {
@@ -25216,7 +26196,7 @@
           "description": "Default color scheme for nominal color scales."
         },
         "numberingOffset": {
-          "description": "The numbering offset used when formatting tick labels on index and locus scales.\n\n__Default value:__ `0`",
+          "description": "The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values.\n\n__Default value:__ `0`",
           "type": "number"
         },
         "ordinal": {
@@ -25348,7 +26328,7 @@
               "description": "Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.\n\nFor quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.\n\n__Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise."
             },
             "numberingOffset": {
-              "description": "The numbering offset used when formatting tick labels on index and locus scales.\n\n__Default value:__ `0`",
+              "description": "The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values.\n\n__Default value:__ `0`",
               "type": "number"
             },
             "padding": {
@@ -25583,7 +26563,7 @@
               "description": "Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of _[0.201479…, 0.996679…]_, a nice domain might be _[0.2, 1.0]_.\n\nFor quantitative scales such as linear, `nice` can be either a boolean flag or a number. If `nice` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain.\n\n__Default value:__ `true` for unbinned _quantitative_ fields; `false` otherwise."
             },
             "numberingOffset": {
-              "description": "The numbering offset used when formatting tick labels on index and locus scales.\n\n__Default value:__ `0`",
+              "description": "The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values.\n\n__Default value:__ `0`",
               "type": "number"
             },
             "padding": {
@@ -26227,9 +27207,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -26253,9 +27251,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "zindex": {
           "description": "Z-order of the separator relative to the view content.\n\nValues greater than `0` render after the view marks. Values less than or equal to `0` render before the marks.\n\n__Default value:__ `0`",
@@ -26489,6 +27505,14 @@
     "Step": {
       "additionalProperties": false,
       "properties": {
+        "for": {
+          "description": "Selects which discrete scale the step describes when a positional scale has a nested offset scale. `\"offset\"` sizes each subgroup step; `\"position\"` sizes each primary category step.\n\n__Default value:__ `\"offset\"` when a discrete nested offset scale is present, otherwise `\"position\"`.",
+          "enum": [
+            "position",
+            "offset"
+          ],
+          "type": "string"
+        },
         "step": {
           "anyOf": [
             {
@@ -27069,6 +28093,7 @@
                   "$ref": "#/definitions/ExprRef"
                 }
               ],
+              "deprecated": "Use `xOffset` instead.",
               "description": "Horizontal offset in pixels.\n\n**Default value:** `0`"
             },
             {
@@ -27092,6 +28117,7 @@
                   "$ref": "#/definitions/ExprRef"
                 }
               ],
+              "deprecated": "Use `yOffset` instead. Note that positive `yOffset` values\nmove down, while positive `dy` values move up.",
               "description": "Vertical offset in pixels.\n\n**Default value:** `0`"
             },
             {
@@ -27103,6 +28129,13 @@
               "type": "number"
             }
           ]
+        },
+        "extraValues": {
+          "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
         },
         "fill": {
           "anyOf": [
@@ -27893,7 +28926,7 @@
               "$ref": "#/definitions/ExprRef"
             }
           ],
-          "description": "One of `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, `\"triangle-left\"`, `\"tick-up\"`, `\"tick-down\"`, `\"tick-right\"`, or `\"tick-left\"`\n\n**Default value:** `\"circle\"`"
+          "description": "One of `\"circle\"`, `\"square\"`, `\"cross\"`, `\"x\"`, `\"+\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, `\"triangle-left\"`, `\"tick-up\"`, `\"tick-down\"`, `\"tick-right\"`, or `\"tick-left\"`. The `\"x\"` and `\"+\"` shapes are stroke-only and use `strokeWidth` for their line thickness.\n\n**Default value:** `\"circle\"`"
         },
         "size": {
           "anyOf": [
@@ -28416,9 +29449,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -28442,9 +29493,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "zindex": {
           "anyOf": [
@@ -28841,9 +29910,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -28867,9 +29954,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "type": "object"
@@ -29176,9 +30281,27 @@
           ],
           "description": "The secondary position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -29202,9 +30325,27 @@
           ],
           "description": "The secondary position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "required": [
@@ -29375,9 +30516,27 @@
           ],
           "description": "Position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -29390,9 +30549,27 @@
           ],
           "description": "Position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "type": "object"
@@ -29564,9 +30741,27 @@
           ],
           "description": "Position on the x axis."
         },
+        "x2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x2` coordinate in logical pixels. When `x2` is implicit, it inherits `xOffset` unless this property is specified.\n\n**Default value:** inherited from `xOffset` for an implicit `x2`, otherwise `0`"
+        },
         "xOffset": {
-          "description": "Offsets of the `x` and `x2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `x` coordinate in logical pixels.\n\n**Default value:** `0`"
         },
         "y": {
           "anyOf": [
@@ -29579,9 +30774,27 @@
           ],
           "description": "Position on the y axis."
         },
+        "y2Offset": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y2` coordinate in logical pixels. When `y2` is implicit, it inherits `yOffset` unless this property is specified.\n\n**Default value:** inherited from `yOffset` for an implicit `y2`, otherwise `0`"
+        },
         "yOffset": {
-          "description": "Offsets of the `y` and `y2` coordinates in pixels. The offset is applied after the viewport scaling and translation.\n\n**Default value:** `0`",
-          "type": "number"
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ExprRef"
+            }
+          ],
+          "description": "Offset of the `y` coordinate in logical pixels.\n\n**Default value:** `0`"
         }
       },
       "required": [
@@ -29995,6 +31208,9 @@
           "$ref": "#/definitions/CrossParams"
         },
         {
+          "$ref": "#/definitions/Displace1DParams"
+        },
+        {
           "$ref": "#/definitions/FlattenDelimitedParams"
         },
         {
@@ -30352,6 +31568,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -30727,6 +31950,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -31077,6 +32307,12 @@
             },
             "strokeWidth": {
               "$ref": "#/definitions/Legend"
+            },
+            "xOffset": {
+              "$ref": "#/definitions/Legend"
+            },
+            "yOffset": {
+              "$ref": "#/definitions/Legend"
             }
           },
           "type": "object"
@@ -31194,10 +32430,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -31278,10 +32520,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -31362,10 +32610,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -31423,10 +32677,16 @@
             "x2": {
               "$ref": "#/definitions/Scale"
             },
+            "xOffset": {
+              "$ref": "#/definitions/Scale"
+            },
             "y": {
               "$ref": "#/definitions/Scale"
             },
             "y2": {
+              "$ref": "#/definitions/Scale"
+            },
+            "yOffset": {
               "$ref": "#/definitions/Scale"
             }
           },
@@ -31838,6 +33098,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -32213,6 +33480,13 @@
                   "description": "Stroke width of axis domain line\n\n__Default value:__ `1`",
                   "type": "number"
                 },
+                "extraValues": {
+                  "description": "Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed.\n\nThis property is ignored on discrete scales and when `values` is set.",
+                  "items": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
                 "format": {
                   "description": "The format specifier pattern for axis labels. Must be a legal [d3-format](https://github.com/d3/d3-format#locale_format) specifier.",
                   "type": "string"
@@ -32563,6 +33837,12 @@
             },
             "strokeWidth": {
               "$ref": "#/definitions/Legend"
+            },
+            "xOffset": {
+              "$ref": "#/definitions/Legend"
+            },
+            "yOffset": {
+              "$ref": "#/definitions/Legend"
             }
           },
           "type": "object"
@@ -32665,10 +33945,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -32749,10 +34035,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -32833,10 +34125,16 @@
                 "x2": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
+                "xOffset": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
                 "y": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 },
                 "y2": {
+                  "$ref": "#/definitions/ResolutionBehavior"
+                },
+                "yOffset": {
                   "$ref": "#/definitions/ResolutionBehavior"
                 }
               },
@@ -32894,10 +34192,16 @@
             "x2": {
               "$ref": "#/definitions/Scale"
             },
+            "xOffset": {
+              "$ref": "#/definitions/Scale"
+            },
             "y": {
               "$ref": "#/definitions/Scale"
             },
             "y2": {
+              "$ref": "#/definitions/Scale"
+            },
+            "yOffset": {
               "$ref": "#/definitions/Scale"
             }
           },
@@ -33656,6 +34960,31 @@
           "$ref": "#/definitions/ConcatSpec"
         }
       ]
+    },
+    "WigDataFormat": {
+      "additionalProperties": false,
+      "properties": {
+        "parse": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Parse"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "If set to `null`, disable type inference based on the spec and only use type inference based on the data. Alternatively, a parsing directive object can be provided for explicit data types. Each property of the object corresponds to a field name, and the value to the desired data type (one of `\"number\"`, `\"boolean\"`, `\"date\"`, or null (do not parse the field)). For example, `\"parse\": {\"modified_on\": \"date\"}` parses the `modified_on` field in each input record a Date value.\n\nFor `\"date\"`, we parse data based using Javascript's [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse). For Specific date formats can be provided (e.g., `{foo: \"date:'%m%d%Y'\"}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: \"utc:'%m%d%Y'\"}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)"
+        },
+        "type": {
+          "const": "wig",
+          "description": "Parses fixedStep and variableStep WIG records into genomic intervals.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
     },
     "WindowOnlyOp": {
       "description": "Operations that calculate a value from rows in the current window.",

--- a/src/genome_spy/schema/mixins.py
+++ b/src/genome_spy/schema/mixins.py
@@ -155,10 +155,12 @@ class MarkMethodMixin:
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Set the chart mark to ``rect``.
 
@@ -194,10 +196,12 @@ class MarkMethodMixin:
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         properties = {
             "buildIndex": buildIndex,
@@ -231,9 +235,11 @@ class MarkMethodMixin:
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {
@@ -298,9 +304,11 @@ class MarkMethodMixin:
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Set the chart mark to ``point``.
 
@@ -325,7 +333,7 @@ class MarkMethodMixin:
             sampleFacetPadding (float): Additional padding used by sample facets. **Default value:** ``0.1``
             semanticScore (float | ExprRef | dict[str, Any]): The semantic score used by semantic zooming in the point mark. This is primarily intended for internal use. **Default value:** ``0``
             semanticZoomFraction (float | ExprRef | dict[str, Any]): TODO **Default value:** ``0.02``
-            shape (str | ExprRef | dict[str, Any]): One of ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, ``"triangle-left"``, ``"tick-up"``, ``"tick-down"``, ``"tick-right"``, or ``"tick-left"`` **Default value:** ``"circle"``
+            shape (str | ExprRef | dict[str, Any]): One of ``"circle"``, ``"square"``, ``"cross"``, ``"x"``, ``"+"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, ``"triangle-left"``, ``"tick-up"``, ``"tick-down"``, ``"tick-right"``, or ``"tick-left"``. The ``"x"`` and ``"+"`` shapes are stroke-only and use ``strokeWidth`` for their line thickness. **Default value:** ``"circle"``
             size (float | ExprRef | dict[str, Any]): Stroke width of ``"link"`` and ``"rule"`` marks in pixels, the area of the bounding square of ``"point"`` mark, or the font size of ``"text"`` mark.
             stroke (str | ExprRef | dict[str, Any]): The stroke color
             strokeOpacity (float | ExprRef | dict[str, Any]): The stroke opacity. Value between ``0`` and ``1``.
@@ -333,9 +341,11 @@ class MarkMethodMixin:
             style (str | Sequence[str]): Named style reference(s) resolved from ``config.style``. If an array is provided, later styles override earlier ones.
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         properties = {
             "angle": angle,
@@ -366,8 +376,10 @@ class MarkMethodMixin:
             "style": style,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {
@@ -410,10 +422,12 @@ class MarkMethodMixin:
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Set the chart mark to ``rule``.
 
@@ -434,10 +448,12 @@ class MarkMethodMixin:
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         properties = {
             "buildIndex": buildIndex,
@@ -456,9 +472,11 @@ class MarkMethodMixin:
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {
@@ -501,9 +519,11 @@ class MarkMethodMixin:
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Set the chart mark to ``tick``.
 
@@ -524,9 +544,11 @@ class MarkMethodMixin:
             thickness (float): The thickness of the tick mark in pixels. Equivalent to the ``size`` of the underlying rule mark. **Default value:** ``1``
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         properties = {
             "buildIndex": buildIndex,
@@ -545,8 +567,10 @@ class MarkMethodMixin:
             "thickness": thickness,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {
@@ -604,10 +628,12 @@ class MarkMethodMixin:
         viewportEdgeFadeWidthTop: float | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Set the chart mark to ``text``.
 
@@ -648,10 +674,12 @@ class MarkMethodMixin:
             viewportEdgeFadeWidthTop (float): Schema-defined ``viewportEdgeFadeWidthTop`` property.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         properties = {
             "align": align,
@@ -690,9 +718,11 @@ class MarkMethodMixin:
             "viewportEdgeFadeWidthTop": viewportEdgeFadeWidthTop,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {
@@ -762,10 +792,12 @@ class MarkMethodMixin:
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Set the chart mark to ``link``.
 
@@ -792,10 +824,12 @@ class MarkMethodMixin:
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         properties = {
             "arcFadingDistance": arcFadingDistance,
@@ -820,9 +854,11 @@ class MarkMethodMixin:
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {
@@ -902,10 +938,12 @@ class MarkMethodMixin:
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Set the chart mark to ``arrow``.
 
@@ -939,10 +977,12 @@ class MarkMethodMixin:
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         properties = {
             "buildIndex": buildIndex,
@@ -974,9 +1014,11 @@ class MarkMethodMixin:
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {
@@ -1041,9 +1083,11 @@ class MarkMethodMixin:
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Set the chart mark to ``point``.
 
@@ -1068,7 +1112,7 @@ class MarkMethodMixin:
             sampleFacetPadding (float): Additional padding used by sample facets. **Default value:** ``0.1``
             semanticScore (float | ExprRef | dict[str, Any]): The semantic score used by semantic zooming in the point mark. This is primarily intended for internal use. **Default value:** ``0``
             semanticZoomFraction (float | ExprRef | dict[str, Any]): TODO **Default value:** ``0.02``
-            shape (str | ExprRef | dict[str, Any]): One of ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, ``"triangle-left"``, ``"tick-up"``, ``"tick-down"``, ``"tick-right"``, or ``"tick-left"`` **Default value:** ``"circle"``
+            shape (str | ExprRef | dict[str, Any]): One of ``"circle"``, ``"square"``, ``"cross"``, ``"x"``, ``"+"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, ``"triangle-left"``, ``"tick-up"``, ``"tick-down"``, ``"tick-right"``, or ``"tick-left"``. The ``"x"`` and ``"+"`` shapes are stroke-only and use ``strokeWidth`` for their line thickness. **Default value:** ``"circle"``
             size (float | ExprRef | dict[str, Any]): Stroke width of ``"link"`` and ``"rule"`` marks in pixels, the area of the bounding square of ``"point"`` mark, or the font size of ``"text"`` mark.
             stroke (str | ExprRef | dict[str, Any]): The stroke color
             strokeOpacity (float | ExprRef | dict[str, Any]): The stroke opacity. Value between ``0`` and ``1``.
@@ -1076,9 +1120,11 @@ class MarkMethodMixin:
             style (str | Sequence[str]): Named style reference(s) resolved from ``config.style``. If an array is provided, later styles override earlier ones.
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         properties = {
             "angle": angle,
@@ -1109,8 +1155,10 @@ class MarkMethodMixin:
             "style": style,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {
@@ -1286,6 +1334,13 @@ class EncodingMethodMixin:
         | Sequence[Channel | SchemaBase | str | dict[str, Any]]
         | None
         | UndefinedType = Undefined,
+        xOffset: Channel
+        | SchemaBase
+        | str
+        | dict[str, Any]
+        | Sequence[Channel | SchemaBase | str | dict[str, Any]]
+        | None
+        | UndefinedType = Undefined,
         y: Channel
         | SchemaBase
         | str
@@ -1300,6 +1355,13 @@ class EncodingMethodMixin:
         | Sequence[Channel | SchemaBase | str | dict[str, Any]]
         | None
         | UndefinedType = Undefined,
+        yOffset: Channel
+        | SchemaBase
+        | str
+        | dict[str, Any]
+        | Sequence[Channel | SchemaBase | str | dict[str, Any]]
+        | None
+        | UndefinedType = Undefined,
     ) -> Self:
         """Return a new specification with merged channel encodings.
 
@@ -1307,8 +1369,8 @@ class EncodingMethodMixin:
             angle (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Rotation angle of point and text marks.
             color (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Color of the marks – either fill or stroke color based on the ``filled`` property of mark definition. Note: 1) For fine-grained control over both fill and stroke colors of the marks, please use the ``fill`` and ``stroke`` channels. The ``fill`` or ``stroke`` encodings have higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified. 2) See the scale documentation for more information about customizing color scheme.
             direction (DirectionDef | dict[str, Any]): Direction of arrow marks. Encoded values are mapped with a discrete scale whose range values must be ``"forward"`` or ``"reverse"``. This channel is supported by arrow marks only and does not create a legend.
-            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dx`` property.
-            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Schema-defined ``dy`` property.
+            dx (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy horizontal pixel offset for point marks.
+            dy (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef): Legacy vertical pixel offset for point marks. Positive values move in the opposite direction from ``yOffset``.
             facetIndex (FieldDefWithoutScale | dict[str, Any]): For internal use
             fill (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Fill color of the marks. Note: The ``fill`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             fillOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Fill opacity of the marks.
@@ -1317,7 +1379,7 @@ class EncodingMethodMixin:
             sample (FieldDefWithoutScale | dict[str, Any]): Facet identifier for interactive filtering, sorting, and grouping in the App.
             search (FieldDefWithoutScale | dict[str, Any] | Sequence[FieldDefWithoutScale | dict[str, Any]]): One or more fields used by the App's location/search input to match data objects in this view. Use a single field definition for simple search, or an array for matching against multiple fields. A datum matches when any configured search field matches the entered term.
             semanticScore (dict[str, Any]): Schema-defined ``semanticScore`` property.
-            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - centered directional shape ``"triangle"``
+            shape (FieldOrDatumDefWithConditionMarkPropFieldDefTypeForShapeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefTypeForShape | ValueDefWithConditionStringNullTypeForShape): Shape of the mark. For ``point`` marks the supported values include: - plotting shapes: ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, or ``"triangle-left"``. - stroke-only ``"x"`` and ``"+"`` shapes, whose line thickness is controlled by ``strokeWidth`` - centered directional shape ``"triangle"``
             size (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Size of the mark. - For ``"point"`` – the symbol size, or pixel area of the mark. - For ``"text"`` – the text's font size. - For ``"arrow"`` – the stem thickness in pixels.
             stroke (FieldOrDatumDefWithConditionMarkPropFieldDefTypeStringNull | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefStringNull | MarkPropExprDefType | ValueDefWithConditionStringNullType): Stroke color of the marks. Note: The ``stroke`` encoding has higher precedence than ``color``, thus may override the ``color`` encoding if conflicting encodings are specified.
             strokeOpacity (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType): Stroke opacity of the marks.
@@ -1327,8 +1389,10 @@ class EncodingMethodMixin:
             uniqueId (FieldDefWithoutScale | dict[str, Any]): For internal use
             x (dict[str, Any] | None): X coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             x2 (Position2Def | dict[str, Any] | None): X2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            xOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Horizontal offset from the encoded x position, in logical pixels.
             y (PositionFieldDef | dict[str, Any] | ChromPosDef | PositionDatumDef | PositionExprDef | ValueDefNumber | None): Y coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
             y2 (Position2Def | dict[str, Any] | None): Y2 coordinates of the marks. The ``value`` of this channel can be a number between zero and one.
+            yOffset (FieldOrDatumDefWithConditionMarkPropFieldDefTypeNumber | dict[str, Any] | FieldOrDatumDefWithConditionScaleDatumDefNumber | MarkPropExprDefType | ValueDefWithConditionNumberType | MarkPropExprDef | None): Vertical offset from the encoded y position, in logical pixels.
         """
         properties = {
             "angle": angle,
@@ -1354,8 +1418,10 @@ class EncodingMethodMixin:
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {
             key: value for key, value in properties.items() if value is not Undefined
@@ -1393,8 +1459,10 @@ class ResolutionMethodMixin:
         uniqueId: ResolutionBehavior_T | UndefinedType = Undefined,
         x: ResolutionBehavior_T | UndefinedType = Undefined,
         x2: ResolutionBehavior_T | UndefinedType = Undefined,
+        xOffset: ResolutionBehavior_T | UndefinedType = Undefined,
         y: ResolutionBehavior_T | UndefinedType = Undefined,
         y2: ResolutionBehavior_T | UndefinedType = Undefined,
+        yOffset: ResolutionBehavior_T | UndefinedType = Undefined,
     ) -> Self:
         """Return a copy with merged axis resolutions."""
         properties = {
@@ -1422,8 +1490,10 @@ class ResolutionMethodMixin:
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {
             key: value for key, value in properties.items() if value is not Undefined
@@ -1457,8 +1527,10 @@ class ResolutionMethodMixin:
         uniqueId: ResolutionBehavior_T | UndefinedType = Undefined,
         x: ResolutionBehavior_T | UndefinedType = Undefined,
         x2: ResolutionBehavior_T | UndefinedType = Undefined,
+        xOffset: ResolutionBehavior_T | UndefinedType = Undefined,
         y: ResolutionBehavior_T | UndefinedType = Undefined,
         y2: ResolutionBehavior_T | UndefinedType = Undefined,
+        yOffset: ResolutionBehavior_T | UndefinedType = Undefined,
     ) -> Self:
         """Return a copy with merged legend resolutions."""
         properties = {
@@ -1486,8 +1558,10 @@ class ResolutionMethodMixin:
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {
             key: value for key, value in properties.items() if value is not Undefined
@@ -1521,8 +1595,10 @@ class ResolutionMethodMixin:
         uniqueId: ResolutionBehavior_T | UndefinedType = Undefined,
         x: ResolutionBehavior_T | UndefinedType = Undefined,
         x2: ResolutionBehavior_T | UndefinedType = Undefined,
+        xOffset: ResolutionBehavior_T | UndefinedType = Undefined,
         y: ResolutionBehavior_T | UndefinedType = Undefined,
         y2: ResolutionBehavior_T | UndefinedType = Undefined,
+        yOffset: ResolutionBehavior_T | UndefinedType = Undefined,
     ) -> Self:
         """Return a copy with merged scale resolutions."""
         properties = {
@@ -1550,8 +1626,10 @@ class ResolutionMethodMixin:
             "uniqueId": uniqueId,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {
             key: value for key, value in properties.items() if value is not Undefined
@@ -1741,8 +1819,10 @@ class TopLevelMergeMixin:
         strokeWidth: core.Scale | ScaleKwds | UndefinedType = Undefined,
         x: core.Scale | ScaleKwds | UndefinedType = Undefined,
         x2: core.Scale | ScaleKwds | UndefinedType = Undefined,
+        xOffset: core.Scale | ScaleKwds | UndefinedType = Undefined,
         y: core.Scale | ScaleKwds | UndefinedType = Undefined,
         y2: core.Scale | ScaleKwds | UndefinedType = Undefined,
+        yOffset: core.Scale | ScaleKwds | UndefinedType = Undefined,
     ) -> Self:
         """Return a copy with merged top-level ``scales``.
 
@@ -1762,8 +1842,10 @@ class TopLevelMergeMixin:
             strokeWidth (Scale | ScaleKwds): Schema-defined ``strokeWidth`` property.
             x (Scale | ScaleKwds): Schema-defined ``x`` property.
             x2 (Scale | ScaleKwds): Schema-defined ``x2`` property.
+            xOffset (Scale | ScaleKwds): Schema-defined ``xOffset`` property.
             y (Scale | ScaleKwds): Schema-defined ``y`` property.
             y2 (Scale | ScaleKwds): Schema-defined ``y2`` property.
+            yOffset (Scale | ScaleKwds): Schema-defined ``yOffset`` property.
         """
         defined = {
             "angle": angle,
@@ -1781,8 +1863,10 @@ class TopLevelMergeMixin:
             "strokeWidth": strokeWidth,
             "x": x,
             "x2": x2,
+            "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
         return self._merge_top_level("scales", value, defined)  # type: ignore[attr-defined, no-any-return]
@@ -1910,6 +1994,7 @@ class UnitPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -1992,7 +2077,7 @@ class UnitPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): The background of the view, including fill, stroke, and stroke width.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -2112,6 +2197,7 @@ class UnitPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -2193,7 +2279,7 @@ class UnitPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): The background of the view, including fill, stroke, and stroke width.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -2313,6 +2399,7 @@ class UnitPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -2394,7 +2481,7 @@ class UnitPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): The background of the view, including fill, stroke, and stroke width.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -2515,6 +2602,7 @@ class LayerPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -2597,7 +2685,7 @@ class LayerPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): Schema-defined ``view`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -2715,6 +2803,7 @@ class LayerPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -2796,7 +2885,7 @@ class LayerPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): Schema-defined ``view`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -2914,6 +3003,7 @@ class LayerPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -2995,7 +3085,7 @@ class LayerPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): Schema-defined ``view`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -3118,6 +3208,7 @@ class HConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -3200,7 +3291,7 @@ class HConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
             visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -3319,6 +3410,7 @@ class HConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -3400,7 +3492,7 @@ class HConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
             visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -3519,6 +3611,7 @@ class HConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -3600,7 +3693,7 @@ class HConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
             visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -3722,6 +3815,7 @@ class VConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -3803,7 +3897,7 @@ class VConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             vconcat (Sequence[UnitSpec | dict[str, Any] | LayerSpec | MultiscaleSpec | VConcatSpec | HConcatSpec | ConcatSpec | ImportSpec]): Schema-defined ``vconcat`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -3912,6 +4006,7 @@ class VConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -4003,7 +4098,7 @@ class VConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             vconcat (Sequence[UnitSpec | dict[str, Any] | LayerSpec | MultiscaleSpec | VConcatSpec | HConcatSpec | ConcatSpec | ImportSpec]): Schema-defined ``vconcat`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -4112,6 +4207,7 @@ class VConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -4203,7 +4299,7 @@ class VConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             vconcat (Sequence[UnitSpec | dict[str, Any] | LayerSpec | MultiscaleSpec | VConcatSpec | HConcatSpec | ConcatSpec | ImportSpec]): Schema-defined ``vconcat`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -4327,6 +4423,7 @@ class ConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -4410,7 +4507,7 @@ class ConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
             visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -4531,6 +4628,7 @@ class ConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -4613,7 +4711,7 @@ class ConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
             visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -4734,6 +4832,7 @@ class ConcatPropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -4816,7 +4915,7 @@ class ConcatPropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
             visible (bool): The default visibility of the view. An invisible view is removed from the layout and not rendered. For context, see toggleable view visibility. **Default:** ``true``
@@ -4942,6 +5041,7 @@ class MultiscalePropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -5025,7 +5125,7 @@ class MultiscalePropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): Schema-defined ``view`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -5149,6 +5249,7 @@ class MultiscalePropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -5231,7 +5332,7 @@ class MultiscalePropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): Schema-defined ``view`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -5355,6 +5456,7 @@ class MultiscalePropertiesMixin:
             | core.CoverageParams
             | core.CoordinateLookupParams
             | core.CrossParams
+            | core.Displace1DParams
             | core.FlattenDelimitedParams
             | core.FormulaParams
             | core.LookupParams
@@ -5437,7 +5539,7 @@ class MultiscalePropertiesMixin:
             templates (dict[str, Any]): Schema-defined ``templates`` property.
             theme (BuiltInThemeName_T | Sequence[BuiltInThemeName_T]): Selects built-in theme preset(s) for the whole visualization.
             title (str | Title | TitleKwds): View title.
-            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
+            transform (Sequence[AlignmentMismatchesParams | dict[str, Any] | AggregateParams | CollectParams | CoverageParams | CoordinateLookupParams | CrossParams | Displace1DParams | FlattenDelimitedParams | FormulaParams | LookupParams | ExprFilterParams | SelectionFilterParams | FilterScoredLabelsParams | FlattenParams | FlattenCompressedExonsParams | FlattenCigarParams | FlattenSequenceParams | IdentifierParams | LinearizeGenomicCoordinateParams | MeasureTextParams | TruncateTextParams | PackLegendLabelsParams | MergeFacetsParams | PileupParams | ProjectParams | RegexExtractParams | RegexFoldParams | SampleParams | SetIntersectionParams | StackParams | WindowParams]): An array of transformations applied to the data before visual encoding.
             view (ViewBackground | ViewBackgroundKwds): Schema-defined ``view`` property.
             viewportHeight (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport height of the view. If the view size exceeds the viewport height, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``height``)
             viewportWidth (SizeDef | SizeDefKwds | float | ExprRef | dict[str, Any] | Literal['container']): Optional viewport width of the view. If the view size exceeds the viewport width, it will be shown with scrollbars. This property implicitly enables clipping. If an expression reference is provided, it must resolve to a number or ``"container"``. **Default:** ``null`` (same as ``width``)
@@ -5658,10 +5760,12 @@ class ConfigMethodMixin:
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Return a chart with ``arrow`` config updated.
 
@@ -5695,10 +5799,12 @@ class ConfigMethodMixin:
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -5730,9 +5836,11 @@ class ConfigMethodMixin:
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -5772,6 +5880,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -5850,6 +5959,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -5926,6 +6036,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -6009,6 +6120,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -6087,6 +6199,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -6163,6 +6276,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -6246,6 +6360,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -6324,6 +6439,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -6400,6 +6516,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -6483,6 +6600,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -6561,6 +6679,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -6637,6 +6756,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -6720,6 +6840,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -6798,6 +6919,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -6874,6 +6996,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -6957,6 +7080,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -7035,6 +7159,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -7111,6 +7236,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -7194,6 +7320,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -7272,6 +7399,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -7348,6 +7476,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -7431,6 +7560,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -7509,6 +7639,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -7585,6 +7716,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -7668,6 +7800,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -7746,6 +7879,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -7822,6 +7956,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -7905,6 +8040,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -7983,6 +8119,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -8059,6 +8196,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -8142,6 +8280,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -8220,6 +8359,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -8296,6 +8436,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -8379,6 +8520,7 @@ class ConfigMethodMixin:
         domainDash: Sequence[float] | UndefinedType = Undefined,
         domainDashOffset: float | UndefinedType = Undefined,
         domainWidth: float | UndefinedType = Undefined,
+        extraValues: Sequence[float] | UndefinedType = Undefined,
         format: str | UndefinedType = Undefined,
         grid: bool | UndefinedType = Undefined,
         gridCap: Literal["butt", "round", "square"] | UndefinedType = Undefined,
@@ -8457,6 +8599,7 @@ class ConfigMethodMixin:
             domainDash (Sequence[float]): An array of alternating [stroke, space] lengths for dashed domain lines.
             domainDashOffset (float): The pixel offset at which to start drawing with the domain dash array.
             domainWidth (float): Stroke width of axis domain line __Default value:__ ``1``
+            extraValues (Sequence[float]): Additional tick and label values to include alongside automatically generated ticks on continuous scales. Values outside the visible scale range are omitted and duplicates are removed. This property is ignored on discrete scales and when ``values`` is set.
             format (str): The format specifier pattern for axis labels. Must be a legal d3-format specifier.
             grid (bool): A boolean flag indicating if grid lines should be included as part of the axis. __Default value:__ ``false``
             gridCap (Literal['butt', 'round', 'square']): The stroke cap for the grid line's ending style. One of ``"butt"``, ``"round"`` or ``"square"``. __Default value:__ ``"butt"``
@@ -8533,6 +8676,7 @@ class ConfigMethodMixin:
             "domainDash": domainDash,
             "domainDashOffset": domainDashOffset,
             "domainWidth": domainWidth,
+            "extraValues": extraValues,
             "format": format,
             "grid": grid,
             "gridCap": gridCap,
@@ -8922,10 +9066,12 @@ class ConfigMethodMixin:
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Return a chart with ``link`` config updated.
 
@@ -8952,10 +9098,12 @@ class ConfigMethodMixin:
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "arcFadingDistance": arcFadingDistance,
@@ -8980,9 +9128,11 @@ class ConfigMethodMixin:
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -9014,9 +9164,11 @@ class ConfigMethodMixin:
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Return a chart with ``mark`` config updated.
 
@@ -9031,9 +9183,11 @@ class ConfigMethodMixin:
             style (str | Sequence[str]): Named style reference(s) resolved from ``config.style``. If an array is provided, later styles override earlier ones.
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -9046,8 +9200,10 @@ class ConfigMethodMixin:
             "style": style,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -9112,9 +9268,11 @@ class ConfigMethodMixin:
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Return a chart with ``point`` config updated.
 
@@ -9139,7 +9297,7 @@ class ConfigMethodMixin:
             sampleFacetPadding (float): Additional padding used by sample facets. **Default value:** ``0.1``
             semanticScore (float | ExprRef | dict[str, Any]): The semantic score used by semantic zooming in the point mark. This is primarily intended for internal use. **Default value:** ``0``
             semanticZoomFraction (float | ExprRef | dict[str, Any]): TODO **Default value:** ``0.02``
-            shape (str | ExprRef | dict[str, Any]): One of ``"circle"``, ``"square"``, ``"cross"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, ``"triangle-left"``, ``"tick-up"``, ``"tick-down"``, ``"tick-right"``, or ``"tick-left"`` **Default value:** ``"circle"``
+            shape (str | ExprRef | dict[str, Any]): One of ``"circle"``, ``"square"``, ``"cross"``, ``"x"``, ``"+"``, ``"diamond"``, ``"triangle-up"``, ``"triangle-down"``, ``"triangle-right"``, ``"triangle-left"``, ``"tick-up"``, ``"tick-down"``, ``"tick-right"``, or ``"tick-left"``. The ``"x"`` and ``"+"`` shapes are stroke-only and use ``strokeWidth`` for their line thickness. **Default value:** ``"circle"``
             size (float | ExprRef | dict[str, Any]): Stroke width of ``"link"`` and ``"rule"`` marks in pixels, the area of the bounding square of ``"point"`` mark, or the font size of ``"text"`` mark.
             stroke (str | ExprRef | dict[str, Any]): The stroke color
             strokeOpacity (float | ExprRef | dict[str, Any]): The stroke opacity. Value between ``0`` and ``1``.
@@ -9147,9 +9305,11 @@ class ConfigMethodMixin:
             style (str | Sequence[str]): Named style reference(s) resolved from ``config.style``. If an array is provided, later styles override earlier ones.
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "angle": angle,
@@ -9180,8 +9340,10 @@ class ConfigMethodMixin:
             "style": style,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -9306,10 +9468,12 @@ class ConfigMethodMixin:
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Return a chart with ``rect`` config updated.
 
@@ -9345,10 +9509,12 @@ class ConfigMethodMixin:
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -9382,9 +9548,11 @@ class ConfigMethodMixin:
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -9427,10 +9595,12 @@ class ConfigMethodMixin:
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Return a chart with ``rule`` config updated.
 
@@ -9451,10 +9621,12 @@ class ConfigMethodMixin:
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -9473,9 +9645,11 @@ class ConfigMethodMixin:
             "tooltip": tooltip,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -9567,7 +9741,7 @@ class ConfigMethodMixin:
             nice (bool | float | dict[str, Any]): Extending the domain so that it starts and ends on nice round values. This method typically modifies the scale’s domain, and may only extend the bounds to the nearest round value. Nicing is useful if the domain is computed from data and may be irregular. For example, for a domain of [0.201479…, 0.996679…], a nice domain might be [0.2, 1.0]. For quantitative scales such as linear, ``nice`` can be either a boolean flag or a number. If ``nice`` is a number, it will represent a desired tick count. This allows greater control over the step size used to extend the bounds, guaranteeing that the returned ticks will exactly cover the domain. __Default value:__ ``true`` for unbinned quantitative fields; ``false`` otherwise.
             nominal (dict[str, Any]): Defaults for nominal scales.
             nominalColorScheme (str | SchemeParams | SchemeParamsKwds): Default color scheme for nominal color scales.
-            numberingOffset (float): The numbering offset used when formatting tick labels on index and locus scales. __Default value:__ ``0``
+            numberingOffset (float): The offset added to data values when formatting tick labels on index and locus scales. This property does not transform data values. __Default value:__ ``0``
             ordinal (dict[str, Any]): Defaults for ordinal scales.
             ordinalColorScheme (str | SchemeParams | SchemeParamsKwds): Default color scheme for ordinal color scales.
             padding (float): For continuous scales, expands the scale domain to accommodate the specified number of pixels on each of the scale range. The scale range must represent pixels for this parameter to function as intended. Padding adjustment is performed prior to all other adjustments, including the effects of the ``zero``, ``nice``, ``domainMin``, and ``domainMax`` properties. For band scales, shortcut for setting ``paddingInner`` and ``paddingOuter`` to the same value. For point scales, alias for ``paddingOuter``. __Default value:__ For continuous scales, derived from the scale config's ``continuousPadding``. For band and point scales, see ``paddingInner`` and ``paddingOuter``. By default, Vega-Lite sets padding such that width/height = number of unique values * step.
@@ -9681,10 +9855,12 @@ class ConfigMethodMixin:
         viewportEdgeFadeWidthTop: float | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         x2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y2: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Return a chart with ``text`` config updated.
 
@@ -9725,10 +9901,12 @@ class ConfigMethodMixin:
             viewportEdgeFadeWidthTop (float): Schema-defined ``viewportEdgeFadeWidthTop`` property.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
             x2 (float | ExprRef | dict[str, Any]): The secondary position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
             y2 (float | ExprRef | dict[str, Any]): The secondary position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "align": align,
@@ -9767,9 +9945,11 @@ class ConfigMethodMixin:
             "viewportEdgeFadeWidthTop": viewportEdgeFadeWidthTop,
             "x": x,
             "x2": x2,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
             "y2": y2,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -9812,9 +9992,11 @@ class ConfigMethodMixin:
         | Literal[False]
         | UndefinedType = Undefined,
         x: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        xOffset: float | UndefinedType = Undefined,
+        x2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        xOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
         y: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
-        yOffset: float | UndefinedType = Undefined,
+        y2Offset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
+        yOffset: float | core.ExprRef | dict[str, Any] | UndefinedType = Undefined,
     ) -> Self:
         """Return a chart with ``tick`` config updated.
 
@@ -9835,9 +10017,11 @@ class ConfigMethodMixin:
             thickness (float): The thickness of the tick mark in pixels. Equivalent to the ``size`` of the underlying rule mark. **Default value:** ``1``
             tooltip (HandledTooltip | HandledTooltipKwds | None | Literal[False]): Tooltip handler. If ``null``, no tooltip is shown. If string, specifies the tooltip handler to use.
             x (float | ExprRef | dict[str, Any]): Position on the x axis.
-            xOffset (float): Offsets of the ``x`` and ``x2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            x2Offset (float | ExprRef | dict[str, Any]): Offset of the ``x2`` coordinate in logical pixels. When ``x2`` is implicit, it inherits ``xOffset`` unless this property is specified. **Default value:** inherited from ``xOffset`` for an implicit ``x2``, otherwise ``0``
+            xOffset (float | ExprRef | dict[str, Any]): Offset of the ``x`` coordinate in logical pixels. **Default value:** ``0``
             y (float | ExprRef | dict[str, Any]): Position on the y axis.
-            yOffset (float): Offsets of the ``y`` and ``y2`` coordinates in pixels. The offset is applied after the viewport scaling and translation. **Default value:** ``0``
+            y2Offset (float | ExprRef | dict[str, Any]): Offset of the ``y2`` coordinate in logical pixels. When ``y2`` is implicit, it inherits ``yOffset`` unless this property is specified. **Default value:** inherited from ``yOffset`` for an implicit ``y2``, otherwise ``0``
+            yOffset (float | ExprRef | dict[str, Any]): Offset of the ``y`` coordinate in logical pixels. **Default value:** ``0``
         """
         defined = {
             "buildIndex": buildIndex,
@@ -9856,8 +10040,10 @@ class ConfigMethodMixin:
             "thickness": thickness,
             "tooltip": tooltip,
             "x": x,
+            "x2Offset": x2Offset,
             "xOffset": xOffset,
             "y": y,
+            "y2Offset": y2Offset,
             "yOffset": yOffset,
         }
         defined = {key: item for key, item in defined.items() if item is not Undefined}
@@ -10227,6 +10413,45 @@ class TransformMethodMixin:
         transform["from"] = from_
         if description is not Undefined:
             transform["description"] = description
+        return self._append_transform(transform)  # type: ignore[attr-defined, no-any-return]
+
+    def transform_displace1d(
+        self,
+        *,
+        length: float | Field_T | core.ExprRef | dict[str, Any],
+        pos: Field_T,
+        as_: str | UndefinedType = Undefined,
+        description: str | UndefinedType = Undefined,
+        extent: Sequence[float]
+        | core.ExprRef
+        | dict[str, Any]
+        | UndefinedType = Undefined,
+        positionFactor: float
+        | core.ExprRef
+        | dict[str, Any]
+        | UndefinedType = Undefined,
+    ) -> Self:
+        """Add a ``displace1d`` transform.
+
+        Args:
+            length (float | Field_T | ExprRef | dict[str, Any]): The full collision length, including any desired spacing, or a field containing that length. The value uses the same units as the scaled positions and output displacement. An expression provides a reactive scalar length shared by all rows.
+            pos (Field_T): The field containing the original position. Input rows must be ordered by ascending ``pos * positionFactor``.
+            as\\_ (str): The output field for signed displacement. __Default value:__ ``"displacement"``
+            description (str): A description of the transform step. Can be used for documentation and agent context.
+            extent (Sequence[float] | ExprRef | dict[str, Any]): Preferred outer bounds for the placed collision intervals, expressed in the original ``pos`` coordinate system. The bounds are multiplied by ``positionFactor`` together with the item positions. When all items cannot fit, they remain non-overlapping and extend beyond the bounds by the minimum necessary amount. An expression can update the bounds reactively.
+            positionFactor (float | ExprRef | dict[str, Any]): A multiplier applied to ``pos`` before placement. An expression can convert position units to logical pixels and react to zoom or layout changes. Use an ascending ``pos`` sort for a positive factor and a descending sort for a negative factor. Place a ``collect`` transform before this transform to buffer input for expression-driven updates. __Default value:__ ``1``
+        """
+        transform: dict[str, Any] = {"type": "displace1d"}
+        transform["length"] = length
+        transform["pos"] = pos
+        if as_ is not Undefined:
+            transform["as"] = as_
+        if description is not Undefined:
+            transform["description"] = description
+        if extent is not Undefined:
+            transform["extent"] = extent
+        if positionFactor is not Undefined:
+            transform["positionFactor"] = positionFactor
         return self._append_transform(transform)  # type: ignore[attr-defined, no-any-return]
 
     def transform_flatten_delimited(

--- a/src/genome_spy/static/widget.js
+++ b/src/genome_spy/static/widget.js
@@ -1,78 +1,24 @@
-export function toUint8Array(payload) {
-  if (payload instanceof ArrayBuffer) {
-    return new Uint8Array(payload);
+export function datasetApi(api, descriptor) {
+  if (!descriptor.scoped) {
+    return api.datasets;
   }
-  if (ArrayBuffer.isView(payload)) {
-    return new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+  if (!descriptor.owner) {
+    throw new Error(
+      `Dataset "${descriptor.name}" belongs to an unnamed nested view.`
+    );
   }
-  throw new TypeError("Arrow IPC payload must be an ArrayBuffer or typed-array view.");
+  const owner = api.views?.get({ scope: [], view: descriptor.owner });
+  if (!owner) {
+    throw new Error(
+      `Could not find the view that declares dataset "${descriptor.name}".`
+    );
+  }
+  return owner.datasets;
 }
 
-export function revokeObjectUrls(urls, revoke = URL.revokeObjectURL) {
-  for (const url of urls) {
-    revoke(url);
-  }
-}
-
-export function releaseInFlightResources(resources, revoke = URL.revokeObjectURL) {
-  for (const resource of resources) {
-    revokeObjectUrls(resource.objectUrls, revoke);
-  }
-  resources.clear();
-}
-
-export function createRenderSpec(
-  spec,
-  arrowData,
-  { createUrl = URL.createObjectURL, revokeUrl = URL.revokeObjectURL } = {}
-) {
-  const renderSpec = structuredClone(spec);
-  const objectUrls = [];
-  const urlsByName = new Map();
-
-  const visit = (value) => {
-    if (!value || typeof value !== "object") {
-      return;
-    }
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        visit(item);
-      }
-      return;
-    }
-    if (typeof value.url === "string" && value.url.startsWith("arrow://")) {
-      const name = value.url.slice("arrow://".length);
-      const payload = arrowData[name];
-      if (payload === undefined) {
-        throw new Error(`No Arrow IPC payload provided for ${name}.`);
-      }
-      if (value.format?.type && value.format.type !== "arrow") {
-        throw new Error(`Arrow data source ${name} must use format.type "arrow".`);
-      }
-      let url = urlsByName.get(name);
-      if (!url) {
-        url = createUrl(
-          new Blob([toUint8Array(payload)], {
-            type: "application/vnd.apache.arrow.file",
-          })
-        );
-        urlsByName.set(name, url);
-        objectUrls.push(url);
-      }
-      value.url = url;
-      value.format = { ...(value.format || {}), type: "arrow" };
-    }
-    for (const child of Object.values(value)) {
-      visit(child);
-    }
-  };
-
-  try {
-    visit(renderSpec);
-    return { spec: renderSpec, objectUrls };
-  } catch (error) {
-    revokeObjectUrls(objectUrls, revokeUrl);
-    throw error;
+export function setLoading(el, loading) {
+  if (el.style) {
+    el.style.visibility = loading ? "hidden" : "";
   }
 }
 
@@ -86,11 +32,18 @@ export async function renderChart({ model, el, signal }) {
   let parameterSubscriptions = [];
   let renderRevision = 0;
   let syncingParameterValues = false;
-  const inFlightResources = new Set();
+  const datasetListeners = [];
 
   const setError = (error) => {
     model.set("error", String(error));
     model.save_changes();
+  };
+
+  const clearError = () => {
+    if (model.get("error")) {
+      model.set("error", "");
+      model.save_changes();
+    }
   };
 
   const publishParameterValue = (name, value) => {
@@ -107,12 +60,6 @@ export async function renderChart({ model, el, signal }) {
       unsubscribe();
     }
     parameterSubscriptions = [];
-  };
-
-  const releaseResources = (resources) => {
-    if (inFlightResources.delete(resources)) {
-      revokeObjectUrls(resources.objectUrls);
-    }
   };
 
   const attachInteractions = () => {
@@ -169,46 +116,86 @@ export async function renderChart({ model, el, signal }) {
     }
   };
 
+  const applyDataset = async (descriptor) => {
+    const revision = model.get(descriptor.revision_trait) || 0;
+    const currentApi = api;
+    const currentRender = renderRevision;
+    if (!currentApi || revision === 0) {
+      return;
+    }
+
+    const payload = model.get(descriptor.payload_trait);
+    const format = model.get(descriptor.format_trait);
+    try {
+      const datasets = datasetApi(currentApi, descriptor);
+      if (format === "arrow") {
+        await datasets.load(descriptor.name, payload, { type: "arrow" });
+      } else if (format === "records") {
+        datasets.set(descriptor.name, payload);
+      } else {
+        throw new Error(`Unsupported dataset format: ${String(format)}`);
+      }
+      if (
+        signal.aborted ||
+        api !== currentApi ||
+        renderRevision !== currentRender ||
+        model.get(descriptor.revision_trait) !== revision
+      ) {
+        return;
+      }
+      clearError();
+    } catch (error) {
+      if (
+        !signal.aborted &&
+        api === currentApi &&
+        renderRevision === currentRender &&
+        model.get(descriptor.revision_trait) === revision
+      ) {
+        setError(error);
+      }
+    }
+  };
+
   const renderSpec = async () => {
     const revision = ++renderRevision;
     const moduleUrl = model.get("bundle_url");
     const options = model.get("embed_options") || {};
+    const datasets = model.get("dataset_manifest") || [];
+    const hasInitialData = datasets.some(
+      (descriptor) => (model.get(descriptor.revision_trait) || 0) > 0
+    );
 
     if (api?.finalize) {
       api.finalize();
       api = null;
     }
-    releaseInFlightResources(inFlightResources);
+    setLoading(el, hasInitialData);
     el.replaceChildren();
 
-    let resources = null;
     try {
       const module = await import(moduleUrl);
       const embed = module.embed ?? module.default?.embed ?? module.default;
       if (typeof embed !== "function") {
         throw new Error("GenomeSpy embed export was not found.");
       }
-      resources = createRenderSpec(model.get("spec"), model.get("arrow_data") || {});
-      inFlightResources.add(resources);
-      const nextApi = await embed(el, resources.spec, options);
+      const nextApi = await embed(el, model.get("spec"), options);
       if (revision !== renderRevision || signal.aborted) {
         nextApi?.finalize?.();
         return;
       }
       api = nextApi;
-      model.set("error", "");
-      model.save_changes();
       attachInteractions();
+      await Promise.all(datasets.map((descriptor) => applyDataset(descriptor)));
+      if (revision === renderRevision && !signal.aborted) {
+        setLoading(el, false);
+      }
     } catch (error) {
       if (revision !== renderRevision || signal.aborted) {
         return;
       }
+      setLoading(el, false);
       setError(error);
       throw error;
-    } finally {
-      if (resources) {
-        releaseResources(resources);
-      }
     }
   };
 
@@ -217,24 +204,31 @@ export async function renderChart({ model, el, signal }) {
   model.on("change:spec", onSpecChange);
   model.on("change:bundle_url", onSpecChange);
   model.on("change:embed_options", onSpecChange);
-  model.on("change:arrow_data", onSpecChange);
   model.on("change:parameter_values", onParameterValuesChange);
   model.on("change:parameter_names", attachInteractions);
   model.on("change:enable_click_events", attachInteractions);
+  for (const descriptor of model.get("dataset_manifest") || []) {
+    const listener = () => void applyDataset(descriptor);
+    const event = `change:${descriptor.revision_trait}`;
+    model.on(event, listener);
+    datasetListeners.push([event, listener]);
+  }
 
   signal.addEventListener("abort", () => {
     renderRevision += 1;
     model.off("change:spec", onSpecChange);
     model.off("change:bundle_url", onSpecChange);
     model.off("change:embed_options", onSpecChange);
-    model.off("change:arrow_data", onSpecChange);
     model.off("change:parameter_values", onParameterValuesChange);
     model.off("change:parameter_names", attachInteractions);
     model.off("change:enable_click_events", attachInteractions);
+    for (const [event, listener] of datasetListeners) {
+      model.off(event, listener);
+    }
     clearInteractions();
     api?.finalize?.();
     api = null;
-    releaseInFlightResources(inFlightResources);
+    setLoading(el, false);
   });
 
   await renderSpec();

--- a/tests/test_generated_schema_package.py
+++ b/tests/test_generated_schema_package.py
@@ -74,7 +74,7 @@ def test_generated_schema_package_loads_real_genomespy_schema() -> None:
     assert len(schema["definitions"]) >= 200
     assert "UnitSpec" in schema["definitions"]
     assert MARK_TYPES == ("rect", "point", "rule", "tick", "text", "link", "arrow")
-    assert SCHEMA_VERSION == "0.82.0"
+    assert SCHEMA_VERSION == "0.83.1"
 
 
 def test_generated_schema_wrappers_serialize_keyword_properties() -> None:

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -23,18 +23,22 @@ def test_notebook_example_is_valid(notebook_path: Path) -> None:
 @pytest.mark.parametrize(
     "notebook_path",
     [
-        Path("notebooks/genome_spy_interactions.py"),
-        Path("notebooks/genome_spy_arrow.py"),
         Path("notebooks/genome_spy_arrow_reactive.py"),
     ],
 )
-def test_marimo_notebook_emits_visible_output(notebook_path: Path) -> None:
+def test_marimo_notebook_emits_visible_output_and_updates_a_stable_widget(
+    notebook_path: Path,
+) -> None:
     module = _load_python_module(notebook_path)
 
     outputs, definitions = module.app.run()
 
     assert any(output is not None for output in outputs)
     assert hasattr(definitions["chart_widget"], "widget")
+    assert definitions["view"].dataset_names == ("table",)
+    assert 'view.set_dataset("table", filtered_dataframe)' in notebook_path.read_text(
+        encoding="utf-8"
+    )
 
 
 def _load_python_module(path: Path) -> ModuleType:

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,19 +1,38 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 import genome_spy as gs
+import pandas as pd
 import polars as pl
+import pyarrow as pa
+import pytest
 
 
-def test_widget_uses_chart_spec() -> None:
+def _entry(widget: gs.JupyterChart, name: str) -> dict[str, object]:
+    return next(entry for entry in widget.dataset_manifest if entry["name"] == name)
+
+
+def _declared_chart() -> gs.Chart:
+    return (
+        gs.Chart(data={"name": "table"}, datasets={"table": []})
+        .mark_point()
+        .encode(x="x:Q", y="y:Q")
+    )
+
+
+def test_widget_rewrites_eager_records_as_a_named_dataset() -> None:
     chart = gs.Chart(data=[{"x": 1, "y": 2}]).mark_point().encode(x="x:Q", y="y:Q")
 
     widget = chart.widget()
 
-    assert widget.spec == chart.to_dict()
+    assert widget.spec["data"] == {"name": "__genome_spy_python_data_0"}
+    assert widget.spec["datasets"] == {"__genome_spy_python_data_0": [{"x": 1, "y": 2}]}
+    assert widget.dataset_names == ("__genome_spy_python_data_0",)
     assert "import(moduleUrl)" in widget._esm
 
 
-def test_jupyter_chart_accepts_raw_spec_dict() -> None:
+def test_jupyter_chart_rewrites_raw_eager_spec_dict() -> None:
     spec = {
         "$schema": "https://cdn.jsdelivr.net/npm/@genome-spy/core/dist/schema.json",
         "mark": "point",
@@ -23,10 +42,42 @@ def test_jupyter_chart_accepts_raw_spec_dict() -> None:
 
     widget = gs.JupyterChart(spec)
 
-    assert widget.spec == spec
+    assert widget.spec["data"] == {"name": "__genome_spy_python_data_0"}
+    assert widget.spec["datasets"] == {"__genome_spy_python_data_0": [{"x": 1}]}
 
 
-def test_widget_automatically_exposes_binary_arrow_payloads() -> None:
+def test_widget_generated_dataset_names_skip_existing_declarations() -> None:
+    chart = (
+        gs.Chart(data=[{"x": 1}], datasets={"__genome_spy_python_data_0": []})
+        .mark_point()
+        .encode(x="x:Q")
+    )
+
+    widget = chart.widget()
+
+    assert widget.spec["data"] == {"name": "__genome_spy_python_data_1"}
+    assert set(widget.spec["datasets"]) == {
+        "__genome_spy_python_data_0",
+        "__genome_spy_python_data_1",
+    }
+
+
+def test_widget_records_a_named_scoped_dataset_owner() -> None:
+    child = (
+        gs.Chart(data={"name": "table"}, datasets={"table": []})
+        .mark_point()
+        .encode(x="x:Q")
+        .properties(name="child")
+    )
+
+    widget = gs.vconcat(child).widget()
+
+    entry = _entry(widget, "table")
+    assert entry["owner"] == "child"
+    assert entry["scoped"] is True
+
+
+def test_widget_exposes_initial_arrow_payload_in_a_private_trait() -> None:
     chart = (
         gs.Chart(pl.DataFrame({"position": [1, 2], "value": [3.0, 4.0]}))
         .mark_point()
@@ -34,19 +85,117 @@ def test_widget_automatically_exposes_binary_arrow_payloads() -> None:
     )
 
     widget = chart.widget()
+    entry = _entry(widget, "__genome_spy_python_data_0")
 
-    identifier = next(iter(widget.arrow_data))
-    assert widget.spec["data"] == {
-        "url": f"arrow://{identifier}",
-        "format": {"type": "arrow"},
+    assert widget.spec["data"] == {"name": "__genome_spy_python_data_0"}
+    assert widget.spec["datasets"] == {"__genome_spy_python_data_0": []}
+    assert getattr(widget, entry["format_trait"]) == "arrow"
+    assert getattr(widget, entry["revision_trait"]) == 1
+    assert getattr(widget, entry["payload_trait"])[:6] == b"ARROW1"
+    assert "datasets.load" in widget._esm
+    assert "createObjectURL" not in widget._esm
+
+
+@pytest.mark.parametrize(
+    "table",
+    [
+        pl.DataFrame({"x": [1, 2], "y": [3, 4]}),
+        pd.DataFrame({"x": [1, 2], "y": [3, 4]}),
+        pa.table({"x": [1, 2], "y": [3, 4]}),
+        pa.record_batch([[1, 2], [3, 4]], names=["x", "y"]),
+    ],
+)
+def test_set_dataset_serializes_supported_tables_without_rewriting_spec(
+    table: object,
+) -> None:
+    widget = _declared_chart().widget()
+    entry = _entry(widget, "table")
+    original_spec = deepcopy(widget.spec)
+
+    widget.set_dataset("table", table)
+
+    assert widget.spec == original_spec
+    assert getattr(widget, entry["format_trait"]) == "arrow"
+    assert getattr(widget, entry["revision_trait"]) == 1
+    assert getattr(widget, entry["payload_trait"])[:6] == b"ARROW1"
+
+
+def test_set_dataset_changes_only_the_targeted_dataset_traits() -> None:
+    chart = (
+        gs.Chart(
+            data={"name": "table"},
+            datasets={"table": [], "reference": [{"x": 0, "y": 0}]},
+        )
+        .mark_point()
+        .encode(x="x:Q", y="y:Q")
+    )
+    widget = chart.widget()
+    table = _entry(widget, "table")
+    reference = _entry(widget, "reference")
+    reference_state = {
+        trait: getattr(widget, reference[trait])
+        for trait in ("payload_trait", "format_trait", "revision_trait")
     }
-    assert widget.arrow_data[identifier][:6] == b"ARROW1"
-    assert "arrow_data" in widget._esm
-    assert "createObjectURL" in widget._esm
-    assert "revokeObjectURL" in widget._esm
-    assert "renderRevision" in widget._esm
-    assert "toUint8Array" in widget._esm
-    assert "nextApi?.finalize?.()" in widget._esm
+
+    widget.set_dataset("table", pl.DataFrame({"x": [1], "y": [2]}))
+
+    assert getattr(widget, table["revision_trait"]) == 1
+    assert {
+        trait: getattr(widget, reference[trait])
+        for trait in ("payload_trait", "format_trait", "revision_trait")
+    } == reference_state
+
+
+def test_set_dataset_records_is_an_explicit_fallback() -> None:
+    widget = _declared_chart().widget()
+    entry = _entry(widget, "table")
+
+    widget.set_dataset("table", [{"x": 1, "y": 2}], format="records")
+
+    assert getattr(widget, entry["format_trait"]) == "records"
+    assert getattr(widget, entry["payload_trait"]) == [{"x": 1, "y": 2}]
+    assert getattr(widget, entry["revision_trait"]) == 1
+
+
+def test_set_dataset_keeps_previous_state_when_serialization_fails() -> None:
+    widget = _declared_chart().widget()
+    entry = _entry(widget, "table")
+    widget.set_dataset("table", pl.DataFrame({"x": [1]}))
+    before = tuple(
+        getattr(widget, entry[trait])
+        for trait in ("payload_trait", "format_trait", "revision_trait")
+    )
+
+    with pytest.raises(TypeError, match="write_ipc"):
+        widget.set_dataset("table", object())
+
+    assert (
+        tuple(
+            getattr(widget, entry[trait])
+            for trait in ("payload_trait", "format_trait", "revision_trait")
+        )
+        == before
+    )
+
+
+def test_set_data_requires_one_live_dataset() -> None:
+    widget = _declared_chart().widget()
+
+    widget.set_data(pl.DataFrame({"x": [1], "y": [2]}))
+
+    assert getattr(widget, _entry(widget, "table")["revision_trait"]) == 1
+
+
+def test_set_data_reports_ambiguous_dataset_names() -> None:
+    widget = (
+        gs.Chart(data={"name": "first"}, datasets={"first": [], "second": []})
+        .mark_point()
+        .encode(x="x:Q")
+        .widget()
+    )
+
+    with pytest.raises(ValueError, match="exactly one"):
+        widget.set_data(pl.DataFrame({"x": [1]}))
 
 
 def test_widget_exposes_explicit_interaction_state() -> None:

--- a/tests/widget.test.mjs
+++ b/tests/widget.test.mjs
@@ -6,13 +6,9 @@ const source = await readFile(
   new URL("../src/genome_spy/static/widget.js", import.meta.url),
   "utf8"
 );
-const {
-  createRenderSpec,
-  releaseInFlightResources,
-  renderChart,
-  revokeObjectUrls,
-  toUint8Array,
-} = await import(`data:text/javascript,${encodeURIComponent(source)}`);
+const { datasetApi, renderChart } = await import(
+  `data:text/javascript,${encodeURIComponent(source)}`
+);
 
 class MockModel {
   constructor(values) {
@@ -61,234 +57,331 @@ function deferred() {
 }
 
 async function waitFor(predicate) {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
+  for (let attempt = 0; attempt < 30; attempt += 1) {
     if (predicate()) {
       return;
     }
     await new Promise((resolve) => setImmediate(resolve));
   }
-  assert.fail("Timed out waiting for widget render state.");
+  assert.fail("Timed out waiting for widget state.");
 }
 
-function renderFixture() {
-  const model = new MockModel({
-    spec: { data: { url: "arrow://table", format: { type: "arrow" } } },
-    arrow_data: { table: new Uint8Array([1, 2, 3]) },
+function descriptor(name, index, { owner = null, scoped = false } = {}) {
+  return {
+    name,
+    owner,
+    scoped,
+    payload_trait: `_dataset_${index}_payload`,
+    format_trait: `_dataset_${index}_format`,
+    revision_trait: `_dataset_${index}_revision`,
+  };
+}
+
+function fixture(datasets = []) {
+  const values = {
+    spec: { data: { name: "table" }, datasets: { table: [] } },
     bundle_url:
       "data:text/javascript,export const embed=(...args)=>globalThis.__widgetEmbed(...args)",
     embed_options: {},
+    dataset_manifest: datasets,
     parameter_names: [],
     parameter_values: {},
     enable_click_events: false,
-  });
+    error: "",
+  };
+  for (const entry of datasets) {
+    values[entry.payload_trait] = null;
+    values[entry.format_trait] = "arrow";
+    values[entry.revision_trait] = 0;
+  }
   return {
-    model,
+    model: new MockModel(values),
     el: {
       textContent: "",
-      replaceChildren() {},
+      style: {},
+      replaceCount: 0,
+      replaceChildren() {
+        this.replaceCount += 1;
+      },
     },
     controller: new AbortController(),
   };
 }
 
-async function withObjectUrlSpies(callback) {
-  const originalCreate = URL.createObjectURL;
-  const originalRevoke = URL.revokeObjectURL;
-  const created = [];
-  const revoked = [];
-  URL.createObjectURL = () => {
-    const url = `blob:test-${created.length + 1}`;
-    created.push(url);
-    return url;
+function apiFixture({ load, set } = {}) {
+  const loads = [];
+  const sets = [];
+  let finalized = 0;
+  let parameterSubscriptions = 0;
+  let clickListeners = 0;
+  let removedClickListeners = 0;
+  const api = {
+    datasets: {
+      load: async (...args) => {
+        loads.push(args);
+        return load?.(...args);
+      },
+      set: (...args) => {
+        sets.push(args);
+        return set?.(...args);
+      },
+    },
+    getParam() {
+      return {
+        getValue: () => 0,
+        setValue() {},
+        subscribe: () => {
+          parameterSubscriptions += 1;
+          return () => {};
+        },
+      };
+    },
+    addEventListener() {
+      clickListeners += 1;
+    },
+    removeEventListener() {
+      removedClickListeners += 1;
+    },
+    finalize() {
+      finalized += 1;
+    },
   };
-  URL.revokeObjectURL = (url) => revoked.push(url);
-  try {
-    await callback({ created, revoked });
-  } finally {
-    URL.createObjectURL = originalCreate;
-    URL.revokeObjectURL = originalRevoke;
-    delete globalThis.__widgetEmbed;
-  }
+  return {
+    api,
+    loads,
+    sets,
+    get finalized() {
+      return finalized;
+    },
+    get parameterSubscriptions() {
+      return parameterSubscriptions;
+    },
+    get clickListeners() {
+      return clickListeners;
+    },
+    get removedClickListeners() {
+      return removedClickListeners;
+    },
+  };
 }
 
-test("toUint8Array preserves a DataView slice", () => {
-  const payload = new DataView(Uint8Array.from([0, 1, 2, 3]).buffer, 1, 2);
+test("datasetApi uses the top-level dataset API by default", () => {
+  const api = { datasets: { load() {} } };
 
-  assert.deepEqual([...toUint8Array(payload)], [1, 2]);
+  assert.equal(datasetApi(api, descriptor("table", 0)), api.datasets);
 });
 
-test("createRenderSpec creates one Blob URL for repeated Arrow data", async () => {
-  const created = [];
-  const result = createRenderSpec(
-    {
-      layer: [
-        { data: { url: "arrow://signals" } },
-        { data: { url: "arrow://signals", format: { type: "arrow" } } },
-      ],
-    },
-    { signals: new DataView(Uint8Array.from([0, 7, 8, 0]).buffer, 1, 2) },
-    {
-      createUrl: (blob) => {
-        created.push(blob);
-        return "blob:signals";
-      },
-    }
+test("datasetApi addresses a scoped declaration through its owner", () => {
+  const ownerDatasets = { load() {} };
+  const api = {
+    views: { get: ({ scope, view }) => (scope.length === 0 && view === "child" ? { datasets: ownerDatasets } : undefined) },
+  };
+
+  assert.equal(
+    datasetApi(api, descriptor("table", 0, { owner: "child", scoped: true })),
+    ownerDatasets
   );
-
-  assert.equal(created.length, 1);
-  assert.deepEqual([...new Uint8Array(await created[0].arrayBuffer())], [7, 8]);
-  assert.equal(result.objectUrls.length, 1);
-  assert.equal(result.spec.layer[0].data.url, "blob:signals");
-  assert.equal(result.spec.layer[1].data.url, "blob:signals");
-  assert.equal(result.spec.layer[0].data.format.type, "arrow");
 });
 
-test("createRenderSpec revokes already-created URLs when rewriting fails", () => {
-  const revoked = [];
+test("initial Arrow data passes the original DataView directly to Core", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  const payload = new DataView(Uint8Array.from([0, 7, 8, 0]).buffer, 1, 2);
+  testFixture.model.set(entry.payload_trait, payload);
+  testFixture.model.set(entry.revision_trait, 1);
+  const rendered = apiFixture();
+  globalThis.__widgetEmbed = async () => rendered.api;
 
-  assert.throws(
-    () =>
-      createRenderSpec(
-        {
-          layer: [
-            { data: { url: "arrow://present" } },
-            { data: { url: "arrow://missing" } },
-          ],
-        },
-        { present: new Uint8Array([1]) },
-        {
-          createUrl: () => "blob:present",
-          revokeUrl: (url) => revoked.push(url),
-        }
-      ),
-    /No Arrow IPC payload provided for missing/
-  );
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
 
-  assert.deepEqual(revoked, ["blob:present"]);
+  assert.equal(rendered.loads.length, 1);
+  assert.deepEqual(rendered.loads[0], ["table", payload, { type: "arrow" }]);
+  assert.equal(rendered.finalized, 0);
+  assert.equal(testFixture.el.style.visibility, "");
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
 });
 
-test("revokeObjectUrls revokes each URL", () => {
-  const revoked = [];
+test("a dataset revision updates the current embed without structural rerender", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  const rendered = apiFixture();
+  let embeds = 0;
+  globalThis.__widgetEmbed = async () => {
+    embeds += 1;
+    return rendered.api;
+  };
 
-  revokeObjectUrls(["blob:a", "blob:b"], (url) => revoked.push(url));
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  const initialReplaceCount = testFixture.el.replaceCount;
+  testFixture.model.set(entry.payload_trait, new Uint8Array([1, 2]));
+  testFixture.model.set(entry.revision_trait, 1);
+  testFixture.model.emit(`change:${entry.revision_trait}`);
+  await waitFor(() => rendered.loads.length === 1);
 
-  assert.deepEqual(revoked, ["blob:a", "blob:b"]);
+  assert.equal(embeds, 1);
+  assert.equal(rendered.finalized, 0);
+  assert.equal(testFixture.el.replaceCount, initialReplaceCount);
+  assert.equal(testFixture.el.style.visibility, "");
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
 });
 
-test("releaseInFlightResources revokes stale render URLs", () => {
-  const revoked = [];
-  const resources = new Set([
-    { objectUrls: ["blob:old-a", "blob:old-b"] },
-    { objectUrls: ["blob:new"] },
+test("a dataset update retains parameter subscriptions and click listeners", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  testFixture.model.set("parameter_names", ["threshold"]);
+  testFixture.model.set("parameter_values", { threshold: 2 });
+  testFixture.model.set("enable_click_events", true);
+  const rendered = apiFixture();
+  globalThis.__widgetEmbed = async () => rendered.api;
+
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.model.set(entry.payload_trait, new Uint8Array([1]));
+  testFixture.model.set(entry.revision_trait, 1);
+  testFixture.model.emit(`change:${entry.revision_trait}`);
+  await waitFor(() => rendered.loads.length === 1);
+
+  assert.equal(rendered.parameterSubscriptions, 1);
+  assert.equal(rendered.clickListeners, 1);
+  assert.equal(rendered.removedClickListeners, 0);
+  testFixture.controller.abort();
+  assert.equal(rendered.removedClickListeners, 1);
+  delete globalThis.__widgetEmbed;
+});
+
+test("one dataset update does not apply unchanged datasets", async () => {
+  const first = descriptor("first", 0);
+  const second = descriptor("second", 1);
+  const testFixture = fixture([first, second]);
+  const rendered = apiFixture();
+  globalThis.__widgetEmbed = async () => rendered.api;
+
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.model.set(first.payload_trait, new Uint8Array([1]));
+  testFixture.model.set(first.revision_trait, 1);
+  testFixture.model.emit(`change:${first.revision_trait}`);
+  await waitFor(() => rendered.loads.length === 1);
+
+  assert.equal(rendered.loads[0][0], "first");
+  assert.equal(testFixture.model.get(second.revision_trait), 0);
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
+});
+
+test("multiple rendered views apply pre-mount and future updates independently", async () => {
+  const entry = descriptor("table", 0);
+  const first = fixture([entry]);
+  const second = fixture([entry]);
+  const payload = new Uint8Array([1]);
+  for (const current of [first, second]) {
+    current.model.set(entry.payload_trait, payload);
+    current.model.set(entry.revision_trait, 1);
+  }
+  const firstApi = apiFixture();
+  const secondApi = apiFixture();
+  let calls = 0;
+  globalThis.__widgetEmbed = async () => [firstApi.api, secondApi.api][calls++];
+
+  await Promise.all([
+    renderChart({ ...first, signal: first.controller.signal }),
+    renderChart({ ...second, signal: second.controller.signal }),
   ]);
+  assert.equal(firstApi.loads.length, 1);
+  assert.equal(secondApi.loads.length, 1);
 
-  releaseInFlightResources(resources, (url) => revoked.push(url));
+  for (const current of [first, second]) {
+    current.model.set(entry.payload_trait, new Uint8Array([2]));
+    current.model.set(entry.revision_trait, 2);
+    current.model.emit(`change:${entry.revision_trait}`);
+  }
+  await waitFor(() => firstApi.loads.length === 2 && secondApi.loads.length === 2);
 
-  assert.deepEqual(revoked, ["blob:old-a", "blob:old-b", "blob:new"]);
-  assert.equal(resources.size, 0);
+  first.controller.abort();
+  second.controller.abort();
+  delete globalThis.__widgetEmbed;
 });
 
-test("renderChart revokes Arrow URLs after a successful embed", async () => {
-  await withObjectUrlSpies(async ({ created, revoked }) => {
-    const fixture = renderFixture();
-    globalThis.__widgetEmbed = async () => ({ finalize() {} });
+test("a current decode failure reports an error without finalizing the embed", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  const rendered = apiFixture({ load: async () => { throw new Error("decode failed"); } });
+  globalThis.__widgetEmbed = async () => rendered.api;
 
-    await renderChart({
-      model: fixture.model,
-      el: fixture.el,
-      signal: fixture.controller.signal,
-    });
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.model.set(entry.payload_trait, new Uint8Array([1]));
+  testFixture.model.set(entry.revision_trait, 1);
+  testFixture.model.emit(`change:${entry.revision_trait}`);
+  await waitFor(() => /decode failed/.test(testFixture.model.get("error")));
 
-    assert.deepEqual(created, ["blob:test-1"]);
-    assert.deepEqual(revoked, created);
-    assert.equal(fixture.model.get("error"), "");
-    fixture.controller.abort();
-  });
+  assert.equal(rendered.finalized, 0);
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
 });
 
-test("renderChart reports embed failures and revokes Arrow URLs", async () => {
-  await withObjectUrlSpies(async ({ created, revoked }) => {
-    const fixture = renderFixture();
-    globalThis.__widgetEmbed = async () => {
-      throw new Error("embed failed");
-    };
-
-    await assert.rejects(
-      renderChart({
-        model: fixture.model,
-        el: fixture.el,
-        signal: fixture.controller.signal,
-      }),
-      /embed failed/
-    );
-
-    assert.deepEqual(revoked, created);
-    assert.match(fixture.model.get("error"), /embed failed/);
-    fixture.controller.abort();
+test("stale dataset failures do not overwrite a newer successful update", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  const first = deferred();
+  const second = deferred();
+  const rendered = apiFixture({
+    load: () => (rendered.loads.length === 1 ? first.promise : second.promise),
   });
+  globalThis.__widgetEmbed = async () => rendered.api;
+
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.model.set(entry.payload_trait, new Uint8Array([1]));
+  testFixture.model.set(entry.revision_trait, 1);
+  testFixture.model.emit(`change:${entry.revision_trait}`);
+  await waitFor(() => rendered.loads.length === 1);
+  testFixture.model.set(entry.payload_trait, new Uint8Array([2]));
+  testFixture.model.set(entry.revision_trait, 2);
+  testFixture.model.emit(`change:${entry.revision_trait}`);
+  await waitFor(() => rendered.loads.length === 2);
+  second.resolve();
+  await waitFor(() => testFixture.model.get("error") === "");
+  first.reject(new Error("stale failure"));
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(testFixture.model.get("error"), "");
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
 });
 
-test("renderChart finalizes a stale render and keeps the latest one", async () => {
-  await withObjectUrlSpies(async ({ created, revoked }) => {
-    const fixture = renderFixture();
-    const renders = [deferred(), deferred()];
-    const finalized = [0, 0];
-    let calls = 0;
-    globalThis.__widgetEmbed = () => renders[calls++].promise;
+test("structural rerender finalizes the old embed and reapplies current data", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  testFixture.model.set(entry.payload_trait, new Uint8Array([1]));
+  testFixture.model.set(entry.revision_trait, 1);
+  const first = apiFixture();
+  const second = apiFixture();
+  let calls = 0;
+  globalThis.__widgetEmbed = async () => [first.api, second.api][calls++];
 
-    const initialRender = renderChart({
-      model: fixture.model,
-      el: fixture.el,
-      signal: fixture.controller.signal,
-    });
-    await waitFor(() => calls === 1);
-    fixture.model.emit("change:spec");
-    await waitFor(() => calls === 2);
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.model.emit("change:spec");
+  await waitFor(() => second.loads.length === 1);
 
-    renders[1].resolve({
-      finalize() {
-        finalized[1] += 1;
-      },
-    });
-    await waitFor(() => fixture.model.get("error") === "");
-    renders[0].resolve({
-      finalize() {
-        finalized[0] += 1;
-      },
-    });
-    await initialRender;
-
-    assert.equal(finalized[0], 1);
-    assert.equal(finalized[1], 0);
-    assert.deepEqual(revoked, created);
-
-    fixture.controller.abort();
-    assert.equal(finalized[1], 1);
-  });
+  assert.equal(first.finalized, 1);
+  assert.equal(second.loads.length, 1);
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
 });
 
-test("renderChart releases an in-flight render when disposed", async () => {
-  await withObjectUrlSpies(async ({ created, revoked }) => {
-    const fixture = renderFixture();
-    const pending = deferred();
-    let finalized = 0;
-    globalThis.__widgetEmbed = () => pending.promise;
+test("disposal removes dataset listeners and finalizes the current embed", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  const rendered = apiFixture();
+  globalThis.__widgetEmbed = async () => rendered.api;
 
-    const render = renderChart({
-      model: fixture.model,
-      el: fixture.el,
-      signal: fixture.controller.signal,
-    });
-    await waitFor(() => created.length === 1);
-    fixture.controller.abort();
-    assert.deepEqual(revoked, created);
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.controller.abort();
+  testFixture.model.set(entry.payload_trait, new Uint8Array([1]));
+  testFixture.model.set(entry.revision_trait, 1);
+  testFixture.model.emit(`change:${entry.revision_trait}`);
+  await new Promise((resolve) => setImmediate(resolve));
 
-    pending.resolve({
-      finalize() {
-        finalized += 1;
-      },
-    });
-    await render;
-    assert.equal(finalized, 1);
-  });
+  assert.equal(rendered.finalized, 1);
+  assert.equal(rendered.loads.length, 0);
+  delete globalThis.__widgetEmbed;
 });


### PR DESCRIPTION
## Summary

Implements live AnyWidget dataset updates for issue #2 without recreating the GenomeSpy chart.

- Upgrades the pinned GenomeSpy Core/schema bundle to `0.83.1`.
- Adds `JupyterChart.set_dataset()` for updating named datasets and `set_data()` as a single-dataset convenience method.
- Rewrites eager widget data into named datasets during widget preparation.
- Uses direct Core `datasets.load()` for Arrow payloads and `datasets.set()` for records, preserving the existing embedded chart during data-only updates.
- Adds independent per-dataset payload, format, and revision traits.
- Supports pre-mount updates, multiple rendered views, latest-update-wins behavior, scoped named datasets, cleanup on disposal, and error handling.
- Adds a stable reactive Marimo example using `view.set_dataset("table", filtered_dataframe)`.
- Documents the live dataset update API.