### PR TITLE
ci(release): use trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,8 @@ jobs:
     needs: build
     if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     environment:
       name: testpypi
       url: https://test.pypi.org/p/genome-spy-python
@@ -68,12 +70,13 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
   publish-pypi:
     needs: build
     if: github.event_name == 'release' || inputs.target == 'pypi'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/p/genome-spy-python
@@ -83,5 +86,3 @@ jobs:
           name: distributions
           path: dist
       - uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Summary

- use GitHub OIDC trusted publishing for TestPyPI and PyPI
- remove long-lived publishing-token references
- scope id-token permissions to the publishing jobs

## Validation

- release workflow YAML parsed successfully
- pre-commit hooks passed
- TestPyPI pending publisher registered for the testpypi environment