### PR TITLE
feat(display): add GenomeSpy controls and embed options

### DIFF
--- a/docs/_ext/genomespy_gallery.py
+++ b/docs/_ext/genomespy_gallery.py
@@ -198,10 +198,39 @@ def _tutorial_embed_html(
     height: int,
     title: str,
     identity: str,
+    controls: tuple[str, ...] = (),
+    control_definitions: dict[str, dict[str, str]] | None = None,
+    control_module_urls: dict[str, str] | None = None,
 ) -> str:
     """Return a direct, wrapper-free GenomeSpy embed for a prose page."""
     token = sha256(f"{target}:{identity}".encode()).hexdigest()[:12]
     container_id = f"gs-tutorial-{token}"
+    controls_script = ""
+    if controls:
+        definitions = control_definitions or {}
+        module_urls = control_module_urls or {}
+        controls_script = (
+            "if (c && api) {\n"
+            "  try {\n"
+            f"    const controlNames = {json.dumps(controls)};\n"
+            f"    const controlDefinitions = {json.dumps(definitions)};\n"
+            f"    const moduleUrls = {json.dumps(module_urls)};\n"
+            "    const controlsModule = await import(moduleUrls.core);\n"
+            "    const modules = { core: controlsModule };\n"
+            "    const mounted = [];\n"
+            "    for (const name of controlNames) {\n"
+            "      const definition = controlDefinitions[name];\n"
+            "      if (!modules[definition.module]) {\n"
+            "        modules[definition.module] = await import(moduleUrls[definition.module]);\n"
+            "      }\n"
+            "      mounted.push(modules[definition.module][definition.export]());\n"
+            "    }\n"
+            "    controlsModule.attachControls(c, api, { controls: mounted });\n"
+            "  } catch (error) {\n"
+            "    console.error('GenomeSpy controls failed to load', error);\n"
+            "  }\n"
+            "}\n"
+        )
     return (
         f'<div id="{container_id}" class="gs-doc-embed" '
         f'style="height:{height}px" role="img" '
@@ -210,7 +239,8 @@ def _tutorial_embed_html(
         f"import {{ embed }} from {json.dumps(bundle_url)};\n"
         f"const c = document.getElementById({json.dumps(container_id)});\n"
         f"const spec = {json.dumps(spec, separators=(',', ':'))};\n"
-        "if (c) await embed(c, spec, { bare: true });\n"
+        "const api = c ? await embed(c, spec, { bare: true }) : null;\n"
+        f"{controls_script}"
         "</script>"
     )
 
@@ -505,6 +535,7 @@ class GenomeSpyChart(Directive):
     option_spec = {
         "height": directives.nonnegative_int,
         "title": directives.unchanged_required,
+        "controls": directives.unchanged_required,
     }
 
     def run(self) -> list[nodes.Node]:
@@ -519,6 +550,14 @@ class GenomeSpyChart(Directive):
 
         env = self.state.document.settings.env
         identity = f"{env.docname}:{self.lineno}"
+        controls: tuple[str, ...] = ()
+        if value := self.options.get("controls"):
+            from genome_spy._embed import normalize_controls
+
+            controls = normalize_controls(
+                tuple(name.strip() for name in value.split(",") if name.strip())
+            )
+        control_definitions, control_module_urls = core.default_control_config()
         markup = _tutorial_embed_html(
             target,
             spec,
@@ -526,6 +565,9 @@ class GenomeSpyChart(Directive):
             height=self.options.get("height", 280),
             title=self.options.get("title", target),
             identity=identity,
+            controls=controls,
+            control_definitions=control_definitions,
+            control_module_urls=control_module_urls,
         )
         return [nodes.raw("", markup, format="html")]
 

--- a/docs/tutorials/display_controls.py
+++ b/docs/tutorials/display_controls.py
@@ -1,0 +1,74 @@
+"""Executable snippets used by the display controls user guide."""
+
+from pathlib import Path
+
+import genome_spy as gs
+
+
+variants = [
+    {"chrom": "chr17", "position": 43_044_295, "score": 4.2},
+    {"chrom": "chr17", "position": 43_051_232, "score": 7.8},
+    {"chrom": "chr17", "position": 43_063_418, "score": 5.6},
+]
+
+chart = (
+    gs.Chart(variants)
+    .mark_point(size=110)
+    .encode(
+        x=gs.Locus("chrom", "position")
+        .scale(
+            domain=[
+                {"chrom": "chr17", "pos": 43_040_000},
+                {"chrom": "chr17", "pos": 43_070_000},
+            ]
+        )
+        .title("Position"),
+        y=gs.Y("score:Q").title("Score"),
+    )
+    .properties(assembly="hg38")
+)
+
+
+# display-controls-basic-start
+# Leaving the chart as the final expression uses SVG, PNG, and Inspector.
+chart
+# display-controls-basic-end
+
+
+def display_overrides() -> None:
+    """Display the chart with temporary control choices."""
+    # display-controls-override-start
+    # Display once without controls.
+    chart.display(controls=False)
+
+    # Display only PNG and SVG, in this order.
+    chart.display(controls=["png", "svg"])
+    # display-controls-override-end
+
+
+def inspector_widget() -> gs.JupyterChart:
+    """Create a retained widget with only the Inspector control."""
+    # display-controls-widget-start
+    widget = chart.widget(controls=["inspector"])
+    # display-controls-widget-end
+    return widget
+
+
+def canvas_renderer_widget() -> gs.JupyterChart:
+    """Create a widget with a GenomeSpy embed option."""
+    # display-controls-embed-options-start
+    canvas_widget = chart.widget(embed_options={"renderer": "canvas"})
+    # display-controls-embed-options-end
+    return canvas_widget
+
+
+def save_examples(directory: Path) -> str:
+    """Return HTML and save a control-free copy."""
+    # display-controls-output-start
+    html = chart.to_html(controls=["svg", "png"])
+    chart.save(directory / "variants.html", controls=False)
+    # display-controls-output-end
+    return html
+
+
+CHARTS = {"chart": chart}

--- a/docs/user-guide/display-controls.md
+++ b/docs/user-guide/display-controls.md
@@ -1,0 +1,103 @@
+# Display controls and embed options
+
+GenomeSpy Python adds SVG, PNG, and Inspector controls when it displays a chart.
+The controls appear when the chart is hovered or receives keyboard focus.
+
+```{literalinclude} ../tutorials/display_controls.py
+:language: python
+:start-after: display-controls-basic-start
+:end-before: display-controls-basic-end
+```
+
+```{genomespy-chart} display_controls:chart
+:height: 230
+:title: Variant scores with export and Inspector controls
+:controls: svg,png,inspector
+```
+
+| Control | What it does |
+|---|---|
+| `svg` | Downloads the current view as SVG. |
+| `png` | Downloads the current view as PNG. |
+| `inspector` | Opens the [GenomeSpy Inspector](https://genomespy.app/docs/api/inspector/), a developer view of the chart's live structure, dataflow, and parameters. |
+| `full-window` | Expands the visualization; not enabled by default. |
+
+## Choose or hide controls
+
+Pass `controls=False` to hide all controls. Pass a list to choose the controls
+and their order:
+
+```{literalinclude} ../tutorials/display_controls.py
+:language: python
+:start-after: display-controls-override-start
+:end-before: display-controls-override-end
+:dedent: 4
+```
+
+Here is the same chart with only the PNG control:
+
+```{genomespy-chart} display_controls:chart
+:height: 230
+:title: Variant scores with only the PNG control
+:controls: png
+```
+
+The same option is available when retaining the notebook widget:
+
+```{literalinclude} ../tutorials/display_controls.py
+:language: python
+:start-after: display-controls-widget-start
+:end-before: display-controls-widget-end
+:dedent: 4
+```
+
+Controls are display configuration and are not included in the chart
+specification returned by `to_dict()` or `to_json()`.
+
+## Embed options
+
+`embed_options` are passed directly to GenomeSpy's `embed()` function. This
+example selects the Canvas renderer:
+
+```{literalinclude} ../tutorials/display_controls.py
+:language: python
+:start-after: display-controls-embed-options-start
+:end-before: display-controls-embed-options-end
+:dedent: 4
+```
+
+Controls and embed options can be configured together:
+
+```python
+chart.widget(
+    controls=["png"],
+    embed_options={"renderer": "canvas"},
+)
+```
+
+See GenomeSpy's lists of [embed
+options](https://genomespy.app/docs/api/embed-options/) and
+[controls](https://genomespy.app/docs/api/embedding/#optional-controls).
+
+## HTML output
+
+The controls option also applies to generated HTML:
+
+```{literalinclude} ../tutorials/display_controls.py
+:language: python
+:start-after: display-controls-output-start
+:end-before: display-controls-output-end
+:dedent: 4
+```
+
+JSON output contains only the chart specification, so it does not include
+controls. See [Save and inspect charts](serialization.md) for JSON and HTML
+output.
+
+## Custom browser modules
+
+By default, the widget and generated HTML load version-matched GenomeSpy
+modules from jsDelivr. Self-hosted and offline setups can override
+`bundle_url`, `controls_module_url`, and `inspector_module_url`. GenomeSpy's
+[embedding guide](https://genomespy.app/docs/api/embedding/) lists the browser
+entry points.

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -42,6 +42,8 @@ scales](genomic-axes.md) to learn GenomeSpy's genomic extensions.
   overview brushes, selections, and cursor rulers.
 - [Create and update charts in notebooks](notebooks.md) covers display,
   dataframe transport, and live dataset updates without remounting.
+- [Display controls and embed options](display-controls.md) covers image export,
+  the Inspector, and rendering-time settings.
 - [Save and inspect charts](serialization.md) writes specifications and
   standalone HTML.
 
@@ -85,5 +87,6 @@ annotations
 
 interaction
 notebooks
+display-controls
 serialization
 ```

--- a/docs/user-guide/interaction.md
+++ b/docs/user-guide/interaction.md
@@ -1,6 +1,6 @@
 # Parameters and interaction
 
-Interaction lets a users to change and manipulate a visualization without rebuilding it from scratch. The `genome-spy-python`API follows closely to the parameter ergonomics of
+Interaction lets a users to change and manipulate a visualization without rebuilding it from scratch. The `genome-spy-python`API follows closely the parameter ergonomics of
 [Altair](https://altair-viz.github.io/user_guide/interactions/parameters.html):
 create a handle, attach it to a chart, then reuse that handle in an
 encoding, expression, or filter.

--- a/docs/user-guide/serialization.md
+++ b/docs/user-guide/serialization.md
@@ -58,18 +58,5 @@ Use {py:meth}`~genome_spy.TopLevelSpec.to_html` when integration code needs the 
 than a file. Complete method signatures and validation options are listed in the
 [API reference](../api.md).
 
-The generated HTML calls GenomeSpy's own `embed` function. To adapt it for
-another page or build system, see
-[embedding](https://genomespy.app/docs/api/embedding/) and the available
-[embed options](https://genomespy.app/docs/api/embed-options/), which
-{py:meth}`~genome_spy.TopLevelSpec.widget` also accepts.
-
-`embed_options` configures the browser embedding step; it does not change the
-chart specification. The optional PNG, SVG, Inspector, and full-window controls
-provided by GenomeSpy are attached after embedding and are not currently exposed
-by a Python chart method. They therefore cannot be generated from the
-visualization schema; see GenomeSpy's
-[controls documentation](https://genomespy.app/docs/api/embedding/#optional-controls)
-for the current browser-level contract. In that contract, authors choose an
-ordered control list and may set placement, visibility, and error handling;
-PNG and SVG exports also accept a filename and export settings.
+See [Display controls and embed options](display-controls.md) to choose controls
+or pass settings to GenomeSpy's embed API.

--- a/src/genome_spy/_embed.py
+++ b/src/genome_spy/_embed.py
@@ -1,0 +1,87 @@
+"""Shared rendering configuration for GenomeSpy browser embeds."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Literal, TypeAlias
+
+from genome_spy.schema import SCHEMA_VERSION
+from genome_spy.schemapi import Undefined, UndefinedType
+
+ControlName: TypeAlias = Literal["svg", "png", "inspector", "full-window"]
+Controls: TypeAlias = bool | ControlName | Sequence[ControlName]
+
+_CONTROL_DEFINITIONS: dict[ControlName, tuple[str, str]] = {
+    "svg": ("core", "svgButton"),
+    "png": ("core", "pngButton"),
+    "inspector": ("inspector", "inspectorButton"),
+    "full-window": ("core", "fullWindowButton"),
+}
+DEFAULT_CONTROLS: tuple[ControlName, ...] = ("svg", "png", "inspector")
+SUPPORTED_CONTROLS: tuple[ControlName, ...] = tuple(_CONTROL_DEFINITIONS)
+
+_CORE_PACKAGE_URL = (
+    f"https://cdn.jsdelivr.net/npm/@genome-spy/core@{SCHEMA_VERSION}/dist"
+)
+DEFAULT_EMBED_URL = f"{_CORE_PACKAGE_URL}/bundle/index.es.js"
+DEFAULT_CONTROLS_MODULE_URL = f"{_CORE_PACKAGE_URL}/src/controls.js"
+DEFAULT_INSPECTOR_MODULE_URL = (
+    "https://cdn.jsdelivr.net/npm/"
+    f"@genome-spy/inspector@{SCHEMA_VERSION}/dist/index.es.js"
+)
+
+
+def normalize_controls(
+    controls: Controls | UndefinedType = Undefined,
+) -> tuple[ControlName, ...]:
+    """Return validated control names in display order."""
+    if controls is Undefined or controls is True:
+        return DEFAULT_CONTROLS
+    if controls is False:
+        return ()
+
+    values: Sequence[str]
+    if isinstance(controls, str):
+        values = (controls,)
+    elif isinstance(controls, Sequence):
+        values = controls
+    else:
+        raise TypeError(
+            "controls must be a boolean, a control name, or a sequence of "
+            "control names."
+        )
+
+    normalized: list[ControlName] = []
+    seen: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            raise TypeError("Every control name must be a string.")
+        if value not in SUPPORTED_CONTROLS:
+            expected = ", ".join(repr(name) for name in SUPPORTED_CONTROLS)
+            raise ValueError(
+                f"Unknown GenomeSpy control {value!r}. Expected one of: {expected}."
+            )
+        if value in seen:
+            raise ValueError(f"GenomeSpy control {value!r} was specified twice.")
+        seen.add(value)
+        normalized.append(value)
+    return tuple(normalized)
+
+
+def control_definitions() -> dict[str, dict[str, str]]:
+    """Return browser module and export metadata for supported controls."""
+    return {
+        name: {"module": module, "export": export}
+        for name, (module, export) in _CONTROL_DEFINITIONS.items()
+    }
+
+
+__all__ = [
+    "ControlName",
+    "Controls",
+    "DEFAULT_CONTROLS",
+    "DEFAULT_CONTROLS_MODULE_URL",
+    "DEFAULT_EMBED_URL",
+    "DEFAULT_INSPECTOR_MODULE_URL",
+    "SUPPORTED_CONTROLS",
+]

--- a/src/genome_spy/_widget.py
+++ b/src/genome_spy/_widget.py
@@ -9,10 +9,19 @@ from typing import Any, Literal, cast
 import anywidget
 import traitlets
 
+from genome_spy._embed import (
+    DEFAULT_CONTROLS,
+    DEFAULT_CONTROLS_MODULE_URL,
+    DEFAULT_EMBED_URL,
+    DEFAULT_INSPECTOR_MODULE_URL,
+    Controls,
+    control_definitions,
+    normalize_controls,
+)
 from genome_spy._chart_authoring import json_safe, records_from_data
 from genome_spy._render import _PreparedSpec, prepare_widget_spec
 from genome_spy.arrow import to_arrow_ipc
-from genome_spy.chart import DEFAULT_EMBED_URL
+from genome_spy.schemapi import Undefined, UndefinedType
 
 _ESM_PATH = Path(__file__).with_name("static") / "widget.js"
 _DatasetFormat = Literal["arrow", "records"]
@@ -26,6 +35,16 @@ class JupyterChart(anywidget.AnyWidget):
     spec = traitlets.Dict().tag(sync=True)
     bundle_url = traitlets.Unicode(DEFAULT_EMBED_URL).tag(sync=True)
     embed_options = traitlets.Dict(default_value={}).tag(sync=True)
+    controls = traitlets.List(
+        trait=traitlets.Unicode(), default_value=list[str](DEFAULT_CONTROLS)
+    ).tag(sync=True)
+    _control_definitions = traitlets.Dict(default_value=control_definitions()).tag(
+        sync=True
+    )
+    controls_module_url = traitlets.Unicode(DEFAULT_CONTROLS_MODULE_URL).tag(sync=True)
+    inspector_module_url = traitlets.Unicode(DEFAULT_INSPECTOR_MODULE_URL).tag(
+        sync=True
+    )
     dataset_manifest = traitlets.List(trait=traitlets.Dict(), default_value=[]).tag(
         sync=True
     )
@@ -44,6 +63,9 @@ class JupyterChart(anywidget.AnyWidget):
         *,
         bundle_url: str = DEFAULT_EMBED_URL,
         embed_options: dict[str, Any] | None = None,
+        controls: Controls | UndefinedType = Undefined,
+        controls_module_url: str = DEFAULT_CONTROLS_MODULE_URL,
+        inspector_module_url: str = DEFAULT_INSPECTOR_MODULE_URL,
         parameter_names: Sequence[str] = (),
         parameter_values: Mapping[str, Any] | None = None,
         enable_click_events: bool = False,
@@ -74,6 +96,9 @@ class JupyterChart(anywidget.AnyWidget):
             spec=prepared.spec,
             bundle_url=bundle_url,
             embed_options=embed_options or {},
+            controls=list(normalize_controls(controls)),
+            controls_module_url=controls_module_url,
+            inspector_module_url=inspector_module_url,
             dataset_manifest=[self._manifest_entry(entry) for entry in manifest],
             parameter_names=list(parameter_names),
             parameter_values=dict(parameter_values or {}),

--- a/src/genome_spy/chart.py
+++ b/src/genome_spy/chart.py
@@ -9,6 +9,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Protocol, Self, cast
 from uuid import uuid4
 
+from genome_spy._embed import (
+    DEFAULT_CONTROLS_MODULE_URL,
+    DEFAULT_EMBED_URL,
+    DEFAULT_INSPECTOR_MODULE_URL,
+    Controls,
+    control_definitions,
+    normalize_controls,
+)
 from genome_spy._utils import JsonSpec, compact_json, pretty_json
 from genome_spy._chart_authoring import (
     merge_encoding_definitions,
@@ -55,6 +63,7 @@ from genome_spy.schema.composition import (
 from genome_spy.schemapi import (
     SchemaBase,
     Undefined,
+    UndefinedType,
     merge_mapping_value,
     normalize_mapping_value,
     normalize_schema_value,
@@ -66,7 +75,6 @@ if TYPE_CHECKING:
 
 _CORE_DIST_URL = f"https://cdn.jsdelivr.net/npm/@genome-spy/core@{SCHEMA_VERSION}/dist"
 DEFAULT_SCHEMA_URL = f"{_CORE_DIST_URL}/schema.json"
-DEFAULT_EMBED_URL = f"{_CORE_DIST_URL}/bundle/index.es.js"
 
 
 class _CopyableSpec(Protocol):
@@ -82,7 +90,7 @@ class _SerializableView(Protocol):
 HTML_TEMPLATE = """
 <div id="{container_id}"></div>
 <script type="text/javascript">
-  (function(spec, moduleUrl) {{
+  (function(spec, moduleUrl, embedOptions, controlOptions) {{
     let outputDiv = document.currentScript.previousElementSibling;
     if (!outputDiv || outputDiv.id !== "{container_id}") {{
       outputDiv = document.getElementById("{container_id}");
@@ -99,6 +107,15 @@ HTML_TEMPLATE = """
       throw error;
     }}
 
+    function showControlError(error) {{
+      const message = document.createElement("p");
+      message.setAttribute("role", "status");
+      message.style.color = "red";
+      message.textContent = "GenomeSpy controls failed to load: " + error.message;
+      outputDiv.appendChild(message);
+      console.error(error);
+    }}
+
     (async function() {{
       try {{
         const module = await import(moduleUrl);
@@ -106,12 +123,42 @@ HTML_TEMPLATE = """
         if (typeof embed !== "function") {{
           throw new Error("GenomeSpy embed export was not found.");
         }}
-        await embed(outputDiv, spec);
+        const api = await embed(outputDiv, spec, embedOptions);
+        if (controlOptions.names.length) {{
+          try {{
+            const controlsModule = await import(controlOptions.moduleUrls.core);
+            const modules = {{ core: controlsModule }};
+            const controls = [];
+            for (const name of controlOptions.names) {{
+              const definition = controlOptions.definitions[name];
+              if (!definition) {{
+                throw new Error(`Control ${{name}} has no definition.`);
+              }}
+              if (!modules[definition.module]) {{
+                const moduleUrl = controlOptions.moduleUrls[definition.module];
+                if (!moduleUrl) {{
+                  throw new Error(
+                    `Control module ${{definition.module}} has no URL.`
+                  );
+                }}
+                modules[definition.module] = await import(moduleUrl);
+              }}
+              const factory = modules[definition.module][definition.export];
+              if (typeof factory !== "function") {{
+                throw new Error(`Control ${{name}} is unavailable.`);
+              }}
+              controls.push(factory());
+            }}
+            controlsModule.attachControls(outputDiv, api, {{ controls }});
+          }} catch (error) {{
+            showControlError(error);
+          }}
+        }}
       }} catch (error) {{
         showError(error);
       }}
     }})();
-  }})({spec_json}, {module_url_json});
+  }})({spec_json}, {module_url_json}, {embed_options_json}, {control_options_json});
 </script>
 """.strip()
 
@@ -589,27 +636,136 @@ class TopLevelSpec(TopLevelMergeMixin, EncodingMethodMixin, TransformMethodMixin
         self,
         *,
         bundle_url: str = DEFAULT_EMBED_URL,
+        embed_options: Mapping[str, Any] | None = None,
+        controls: Controls | UndefinedType = Undefined,
+        controls_module_url: str = DEFAULT_CONTROLS_MODULE_URL,
+        inspector_module_url: str = DEFAULT_INSPECTOR_MODULE_URL,
         container_id: str | None = None,
     ) -> str:
-        """Render the spec as a small self-contained HTML snippet."""
+        """Render the chart as an HTML snippet.
+
+        Description:
+            The snippet loads the pinned GenomeSpy browser modules. Controls
+            affect only this HTML representation and are not serialized into
+            the chart specification.
+
+        Args:
+            bundle_url: Browser module containing GenomeSpy's ``embed`` function.
+            embed_options: Options passed directly to ``embed``.
+            controls: Controls to mount, ``True`` for defaults, or ``False`` to
+                disable them.
+            controls_module_url: Browser module containing Core controls.
+            inspector_module_url: Browser module containing the Inspector control.
+            container_id: Optional HTML id for the chart container.
+
+        Returns:
+            An HTML snippet containing the chart specification and embed code.
+
+        Raises:
+            TypeError: If the controls value has an invalid type.
+            ValueError: If a control name is unknown or duplicated.
+
+        Example:
+            >>> chart.to_html(controls=["svg", "png"])
+        """
         container_id = container_id or f"genome-spy-{uuid4().hex}"
         spec_json = compact_json(self.to_dict())
         module_url_json = compact_json(bundle_url)
+        embed_options_json = compact_json(dict(embed_options or {}))
+        control_options_json = compact_json(
+            {
+                "names": normalize_controls(controls),
+                "definitions": control_definitions(),
+                "moduleUrls": {
+                    "core": controls_module_url,
+                    "inspector": inspector_module_url,
+                },
+            }
+        )
         return HTML_TEMPLATE.format(
             container_id=container_id,
             spec_json=spec_json,
             module_url_json=module_url_json,
+            embed_options_json=embed_options_json,
+            control_options_json=control_options_json,
         )
 
-    def save(self, path: str | Path, *, format: str | None = None) -> None:
-        """Save the spec as JSON or HTML based on suffix or explicit format."""
+    def save(
+        self,
+        path: str | Path,
+        *,
+        format: str | None = None,
+        bundle_url: str = DEFAULT_EMBED_URL,
+        embed_options: Mapping[str, Any] | None = None,
+        controls: Controls | UndefinedType = Undefined,
+        controls_module_url: str = DEFAULT_CONTROLS_MODULE_URL,
+        inspector_module_url: str = DEFAULT_INSPECTOR_MODULE_URL,
+    ) -> None:
+        """Save the chart as JSON or HTML.
+
+        Description:
+            The filename suffix selects the format unless ``format`` is given.
+            Rendering controls and embed options apply only to HTML output.
+
+        Args:
+            path: Destination path.
+            format: Explicit ``"json"`` or ``"html"`` format.
+            bundle_url: Browser module containing GenomeSpy's ``embed`` function.
+            embed_options: Options passed directly to ``embed`` for HTML output.
+            controls: HTML controls, ``True`` for defaults, or ``False`` to
+                disable them.
+            controls_module_url: Browser module containing Core controls.
+            inspector_module_url: Browser module containing the Inspector control.
+
+        Returns:
+            None.
+
+        Raises:
+            ValueError: If the format is unsupported or HTML-only options are
+                supplied for JSON output.
+
+        Example:
+            >>> chart.save("chart.html", controls=False)
+        """
         output_path = Path(path)
         file_format = format or output_path.suffix.lstrip(".")
         if file_format == "json":
+            html_options = [
+                name
+                for name, supplied in (
+                    ("bundle_url", bundle_url != DEFAULT_EMBED_URL),
+                    ("embed_options", embed_options is not None),
+                    ("controls", controls is not Undefined),
+                    (
+                        "controls_module_url",
+                        controls_module_url != DEFAULT_CONTROLS_MODULE_URL,
+                    ),
+                    (
+                        "inspector_module_url",
+                        inspector_module_url != DEFAULT_INSPECTOR_MODULE_URL,
+                    ),
+                )
+                if supplied
+            ]
+            if html_options:
+                raise ValueError(
+                    f"The {', '.join(html_options)} option(s) apply only to HTML "
+                    "rendering."
+                )
             output_path.write_text(self.to_json() + "\n", encoding="utf-8")
             return
         if file_format == "html":
-            output_path.write_text(self.to_html() + "\n", encoding="utf-8")
+            output_path.write_text(
+                self.to_html(
+                    bundle_url=bundle_url,
+                    embed_options=embed_options,
+                    controls=controls,
+                    controls_module_url=controls_module_url,
+                    inspector_module_url=inspector_module_url,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
             return
         raise ValueError("Unsupported format. Use 'json' or 'html'.")
 
@@ -618,6 +774,9 @@ class TopLevelSpec(TopLevelMergeMixin, EncodingMethodMixin, TransformMethodMixin
         *,
         bundle_url: str = DEFAULT_EMBED_URL,
         embed_options: dict[str, Any] | None = None,
+        controls: Controls | UndefinedType = Undefined,
+        controls_module_url: str = DEFAULT_CONTROLS_MODULE_URL,
+        inspector_module_url: str = DEFAULT_INSPECTOR_MODULE_URL,
         parameter_names: Sequence[str] = (),
         parameter_values: Mapping[str, Any] | None = None,
         enable_click_events: bool = False,
@@ -627,6 +786,9 @@ class TopLevelSpec(TopLevelMergeMixin, EncodingMethodMixin, TransformMethodMixin
         Args:
             bundle_url: GenomeSpy bundle URL used by the widget.
             embed_options: Options passed to GenomeSpy's ``embed`` function.
+            controls: Display controls, or ``False`` to disable them.
+            controls_module_url: Browser module containing Core controls.
+            inspector_module_url: Browser module containing the Inspector control.
             parameter_names: Named GenomeSpy parameters synchronized with the
                 widget's ``parameter_values`` trait.
             parameter_values: Initial values for the synchronized parameters.
@@ -635,6 +797,13 @@ class TopLevelSpec(TopLevelMergeMixin, EncodingMethodMixin, TransformMethodMixin
 
         Returns:
             An anywidget-backed :class:`JupyterChart`.
+
+        Raises:
+            TypeError: If the controls value has an invalid type.
+            ValueError: If a control name is unknown or duplicated.
+
+        Example:
+            >>> widget = chart.widget(controls=["png", "inspector"])
         """
         from genome_spy.jupyter import JupyterChart
 
@@ -642,9 +811,65 @@ class TopLevelSpec(TopLevelMergeMixin, EncodingMethodMixin, TransformMethodMixin
             self,
             bundle_url=bundle_url,
             embed_options=embed_options,
+            controls=controls,
+            controls_module_url=controls_module_url,
+            inspector_module_url=inspector_module_url,
             parameter_names=parameter_names,
             parameter_values=parameter_values,
             enable_click_events=enable_click_events,
+        )
+
+    def display(
+        self,
+        *,
+        bundle_url: str = DEFAULT_EMBED_URL,
+        embed_options: dict[str, Any] | None = None,
+        controls: Controls | UndefinedType = Undefined,
+        controls_module_url: str = DEFAULT_CONTROLS_MODULE_URL,
+        inspector_module_url: str = DEFAULT_INSPECTOR_MODULE_URL,
+    ) -> None:
+        """Display this chart once with temporary rendering options.
+
+        Description:
+            This mirrors Altair's display-time configuration: the supplied
+            options affect this display call without changing chart JSON.
+
+        Args:
+            bundle_url: Browser module containing GenomeSpy's ``embed`` function.
+            embed_options: Options passed directly to ``embed``.
+            controls: Controls to mount, ``True`` for defaults, or ``False`` to
+                disable them.
+            controls_module_url: Browser module containing Core controls.
+            inspector_module_url: Browser module containing the Inspector control.
+
+        Returns:
+            None.
+
+        Raises:
+            ImportError: If IPython is unavailable.
+            TypeError: If the controls value has an invalid type.
+            ValueError: If a control name is unknown or duplicated.
+
+        Example:
+            >>> chart.display(controls=False)
+        """
+        try:
+            from IPython.display import display
+        except ImportError as error:
+            raise ImportError(
+                "Chart.display() requires IPython. Use chart.to_html() outside "
+                "a notebook."
+            ) from error
+
+        display_chart = cast(Callable[[Any], None], display)
+        display_chart(
+            self.widget(
+                bundle_url=bundle_url,
+                embed_options=embed_options,
+                controls=controls,
+                controls_module_url=controls_module_url,
+                inspector_module_url=inspector_module_url,
+            )
         )
 
     def _repr_mimebundle_(

--- a/src/genome_spy/static/widget.js
+++ b/src/genome_spy/static/widget.js
@@ -22,6 +22,45 @@ export function setLoading(el, loading) {
   }
 }
 
+export async function mountControls({
+  container,
+  api,
+  names,
+  definitions,
+  moduleUrls,
+}) {
+  if (!names.length) {
+    return null;
+  }
+
+  const controlsModule = await import(moduleUrls.core);
+  const modules = { core: controlsModule };
+  const controls = [];
+  for (const name of names) {
+    const definition = definitions[name];
+    if (!definition) {
+      throw new Error(`Control ${name} has no definition.`);
+    }
+    if (!modules[definition.module]) {
+      const moduleUrl = moduleUrls[definition.module];
+      if (!moduleUrl) {
+        throw new Error(`Control module ${definition.module} has no URL.`);
+      }
+      modules[definition.module] = await import(moduleUrl);
+    }
+    const factory = modules[definition.module][definition.export];
+    if (typeof factory !== "function") {
+      throw new Error(`Control ${name} is unavailable.`);
+    }
+    controls.push(factory());
+  }
+
+  if (typeof controlsModule.attachControls !== "function") {
+    throw new Error("GenomeSpy attachControls export was not found.");
+  }
+  return controlsModule.attachControls(container, api, { controls });
+}
+
 export async function renderChart({ model, el, signal }) {
   if (!model.get("spec")) {
     el.textContent = "No GenomeSpy specification provided.";
@@ -29,20 +68,52 @@ export async function renderChart({ model, el, signal }) {
   }
 
   let api = null;
+  let mountedControls = null;
   let parameterSubscriptions = [];
   let renderRevision = 0;
   let syncingParameterValues = false;
   const datasetListeners = [];
+  const activeErrors = new Map();
 
-  const setError = (error) => {
-    model.set("error", String(error));
+  const publishErrors = () => {
+    model.set("error", [...activeErrors.values()].join("\n"));
     model.save_changes();
   };
 
-  const clearError = () => {
-    if (model.get("error")) {
-      model.set("error", "");
-      model.save_changes();
+  const setError = (error, source = "runtime") => {
+    activeErrors.delete(source);
+    activeErrors.set(source, String(error));
+    publishErrors();
+  };
+
+  const clearError = (source) => {
+    if (activeErrors.delete(source)) {
+      publishErrors();
+    }
+  };
+
+  const disposeCurrent = ({ reportErrors = true } = {}) => {
+    const controls = mountedControls;
+    const currentApi = api;
+    mountedControls = null;
+    api = null;
+    const errors = [];
+    try {
+      controls?.dispose?.();
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      currentApi?.finalize?.();
+    } catch (error) {
+      errors.push(error);
+    }
+    if (errors.length && reportErrors) {
+      setError(errors.map(String).join("\n"), "cleanup");
+    } else if (!errors.length) {
+      clearError("cleanup");
+    } else {
+      console.error("GenomeSpy cleanup failed", ...errors);
     }
   };
 
@@ -117,6 +188,7 @@ export async function renderChart({ model, el, signal }) {
   };
 
   const applyDataset = async (descriptor) => {
+    const errorSource = `dataset:${descriptor.revision_trait}`;
     const revision = model.get(descriptor.revision_trait) || 0;
     const currentApi = api;
     const currentRender = renderRevision;
@@ -143,7 +215,7 @@ export async function renderChart({ model, el, signal }) {
       ) {
         return;
       }
-      clearError();
+      clearError(errorSource);
     } catch (error) {
       if (
         !signal.aborted &&
@@ -151,7 +223,7 @@ export async function renderChart({ model, el, signal }) {
         renderRevision === currentRender &&
         model.get(descriptor.revision_trait) === revision
       ) {
-        setError(error);
+        setError(error, errorSource);
       }
     }
   };
@@ -160,15 +232,13 @@ export async function renderChart({ model, el, signal }) {
     const revision = ++renderRevision;
     const moduleUrl = model.get("bundle_url");
     const options = model.get("embed_options") || {};
+    const controlNames = model.get("controls") || [];
     const datasets = model.get("dataset_manifest") || [];
     const hasInitialData = datasets.some(
       (descriptor) => (model.get(descriptor.revision_trait) || 0) > 0
     );
 
-    if (api?.finalize) {
-      api.finalize();
-      api = null;
-    }
+    disposeCurrent();
     setLoading(el, hasInitialData);
     el.replaceChildren();
 
@@ -184,6 +254,36 @@ export async function renderChart({ model, el, signal }) {
         return;
       }
       api = nextApi;
+      clearError("render");
+      try {
+        const nextControls = await mountControls({
+          container: el,
+          api: nextApi,
+          names: controlNames,
+          definitions: model.get("_control_definitions") || {},
+          moduleUrls: {
+            core: model.get("controls_module_url"),
+            inspector: model.get("inspector_module_url"),
+          },
+        });
+        if (revision !== renderRevision || signal.aborted || api !== nextApi) {
+          try {
+            nextControls?.dispose?.();
+          } catch (error) {
+            console.error("GenomeSpy controls cleanup failed", error);
+          }
+          return;
+        }
+        mountedControls = nextControls;
+        clearError("controls");
+      } catch (error) {
+        if (revision === renderRevision && !signal.aborted && api === nextApi) {
+          setError(
+            `GenomeSpy controls failed to load: ${String(error)}`,
+            "controls"
+          );
+        }
+      }
       attachInteractions();
       await Promise.all(datasets.map((descriptor) => applyDataset(descriptor)));
       if (revision === renderRevision && !signal.aborted) {
@@ -194,7 +294,7 @@ export async function renderChart({ model, el, signal }) {
         return;
       }
       setLoading(el, false);
-      setError(error);
+      setError(error, "render");
       throw error;
     }
   };
@@ -204,6 +304,9 @@ export async function renderChart({ model, el, signal }) {
   model.on("change:spec", onSpecChange);
   model.on("change:bundle_url", onSpecChange);
   model.on("change:embed_options", onSpecChange);
+  model.on("change:controls", onSpecChange);
+  model.on("change:controls_module_url", onSpecChange);
+  model.on("change:inspector_module_url", onSpecChange);
   model.on("change:parameter_values", onParameterValuesChange);
   model.on("change:parameter_names", attachInteractions);
   model.on("change:enable_click_events", attachInteractions);
@@ -219,16 +322,21 @@ export async function renderChart({ model, el, signal }) {
     model.off("change:spec", onSpecChange);
     model.off("change:bundle_url", onSpecChange);
     model.off("change:embed_options", onSpecChange);
+    model.off("change:controls", onSpecChange);
+    model.off("change:controls_module_url", onSpecChange);
+    model.off("change:inspector_module_url", onSpecChange);
     model.off("change:parameter_values", onParameterValuesChange);
     model.off("change:parameter_names", attachInteractions);
     model.off("change:enable_click_events", attachInteractions);
     for (const [event, listener] of datasetListeners) {
       model.off(event, listener);
     }
-    clearInteractions();
-    api?.finalize?.();
-    api = null;
-    setLoading(el, false);
+    try {
+      clearInteractions();
+    } finally {
+      disposeCurrent({ reportErrors: false });
+      setLoading(el, false);
+    }
   });
 
   await renderSpec();

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -9,6 +9,14 @@ import genome_spy as gs
 import polars as pl
 import pytest
 
+from genome_spy._embed import (
+    DEFAULT_CONTROLS,
+    DEFAULT_CONTROLS_MODULE_URL,
+    DEFAULT_INSPECTOR_MODULE_URL,
+    SUPPORTED_CONTROLS,
+    control_definitions,
+    normalize_controls,
+)
 from genome_spy.chart import DEFAULT_EMBED_URL, DEFAULT_SCHEMA_URL
 from genome_spy import api as public_api
 from genome_spy._parameters import _select_parameter_class
@@ -1498,6 +1506,81 @@ def test_to_html_embeds_genomespy_runtime() -> None:
     assert "dist/bundle/index.es.js" in html
     assert '"mark":"point"' in html
     assert json.dumps("x") in html
+    assert json.dumps(list(DEFAULT_CONTROLS), separators=(",", ":")) in html
+    assert DEFAULT_CONTROLS_MODULE_URL in html
+    assert DEFAULT_INSPECTOR_MODULE_URL in html
+    assert "import(controlOptions.moduleUrls.core)" in html
+    assert "controlOptions.controlsModuleUrl" not in html
+
+
+def test_to_html_accepts_embed_options_and_disables_controls() -> None:
+    html = (
+        gs.Chart(data=[{"x": 1}])
+        .mark_point()
+        .to_html(embed_options={"renderer": "canvas"}, controls=False)
+    )
+
+    assert "const api = await embed(outputDiv, spec, embedOptions)" in html
+    assert '{"renderer":"canvas"}' in html
+    assert '"names":[]' in html
+
+
+@pytest.mark.parametrize(
+    ("controls", "expected"),
+    [
+        (True, DEFAULT_CONTROLS),
+        (False, ()),
+        ([], ()),
+        ("png", ("png",)),
+        (["png", "svg", "full-window"], ("png", "svg", "full-window")),
+    ],
+)
+def test_control_normalization(controls: object, expected: tuple[str, ...]) -> None:
+    assert normalize_controls(controls) == expected  # type: ignore[arg-type]
+
+
+def test_control_normalization_rejects_unknown_and_duplicate_names() -> None:
+    with pytest.raises(ValueError, match="Unknown GenomeSpy control 'pdf'"):
+        normalize_controls(["pdf"])  # type: ignore[list-item]
+    with pytest.raises(ValueError, match="'png' was specified twice"):
+        normalize_controls(["png", "png"])
+
+
+def test_control_definitions_cover_every_supported_name() -> None:
+    definitions = control_definitions()
+
+    assert tuple(definitions) == SUPPORTED_CONTROLS
+    assert definitions["png"] == {"module": "core", "export": "pngButton"}
+    assert definitions["inspector"] == {
+        "module": "inspector",
+        "export": "inspectorButton",
+    }
+
+
+def test_json_save_rejects_rendering_options(tmp_path: object) -> None:
+    from pathlib import Path
+
+    output = Path(str(tmp_path)) / "chart.json"
+    with pytest.raises(ValueError, match="apply only to HTML"):
+        gs.Chart().mark_point().save(output, controls=False)
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("bundle_url", "https://example.test/core.js"),
+        ("controls_module_url", "https://example.test/controls.js"),
+        ("inspector_module_url", "https://example.test/inspector.js"),
+    ],
+)
+def test_json_save_rejects_custom_browser_modules(
+    tmp_path: object, option: str, value: str
+) -> None:
+    from pathlib import Path
+
+    output = Path(str(tmp_path)) / "chart.json"
+    with pytest.raises(ValueError, match=option):
+        gs.Chart().mark_point().save(output, **{option: value})  # type: ignore[arg-type]
 
 
 def test_runtime_urls_match_generated_schema_version() -> None:
@@ -1505,6 +1588,8 @@ def test_runtime_urls_match_generated_schema_version() -> None:
 
     assert versioned_package in DEFAULT_SCHEMA_URL
     assert versioned_package in DEFAULT_EMBED_URL
+    assert versioned_package in DEFAULT_CONTROLS_MODULE_URL
+    assert f"@genome-spy/inspector@{SCHEMA_VERSION}" in DEFAULT_INSPECTOR_MODULE_URL
 
 
 def test_default_repr_uses_widget_bundle_when_available() -> None:
@@ -1512,6 +1597,19 @@ def test_default_repr_uses_widget_bundle_when_available() -> None:
 
     assert isinstance(bundle, tuple)
     assert "application/vnd.jupyter.widget-view+json" in bundle[0]
+
+
+def test_display_uses_temporary_control_configuration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    displayed: list[object] = []
+    monkeypatch.setattr("IPython.display.display", displayed.append)
+
+    gs.Chart().mark_point().display(controls=False)
+
+    assert len(displayed) == 1
+    assert isinstance(displayed[0], gs.JupyterChart)
+    assert displayed[0].controls == []
 
 
 def test_transform_formula_serializes() -> None:

--- a/tests/test_docs_tutorial.py
+++ b/tests/test_docs_tutorial.py
@@ -50,6 +50,10 @@ NOTEBOOKS_TUTORIAL_PATH = REPO_ROOT / "docs" / "tutorials" / "notebooks.py"
 NOTEBOOKS_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide" / "notebooks.md"
 SERIALIZATION_TUTORIAL_PATH = REPO_ROOT / "docs" / "tutorials" / "serialization.py"
 SERIALIZATION_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide" / "serialization.md"
+DISPLAY_CONTROLS_TUTORIAL_PATH = (
+    REPO_ROOT / "docs" / "tutorials" / "display_controls.py"
+)
+DISPLAY_CONTROLS_GUIDE_PATH = REPO_ROOT / "docs" / "user-guide" / "display-controls.md"
 GALLERY_EXTENSION_PATH = REPO_ROOT / "docs" / "_ext" / "genomespy_gallery.py"
 TUTORIALS_DIR = REPO_ROOT / "docs" / "tutorials"
 
@@ -993,10 +997,64 @@ def test_tutorial_directive_uses_direct_static_bundle_embed() -> None:
 
     assert 'import { embed } from "https://example.test/bundle.js"' in markup
     assert "await embed(c, spec, { bare: true })" in markup
+    assert "attachControls" not in markup
     assert "height:190px" in markup
     assert "iframe" not in markup
     assert "ResizeObserver" not in markup
     assert "attachShadow" not in markup
+
+
+def test_tutorial_directive_can_opt_in_to_controls() -> None:
+    extension = _load_module("_controls_gallery_extension", GALLERY_EXTENSION_PATH)
+    chart = extension._load_tutorial_chart("display_controls:chart")
+    markup = extension._tutorial_embed_html(
+        "display_controls:chart",
+        chart.to_dict(),
+        bundle_url="https://example.test/bundle.js",
+        height=230,
+        title="Display controls",
+        identity="display-controls:1",
+        controls=("svg", "png", "inspector"),
+        control_definitions={
+            "svg": {"module": "core", "export": "svgButton"},
+            "png": {"module": "core", "export": "pngButton"},
+            "inspector": {
+                "module": "inspector",
+                "export": "inspectorButton",
+            },
+        },
+        control_module_urls={
+            "core": "https://example.test/controls.js",
+            "inspector": "https://example.test/inspector.js",
+        },
+    )
+
+    assert 'const controlNames = ["svg", "png", "inspector"]' in markup
+    assert '"core": "https://example.test/controls.js"' in markup
+    assert '"inspector": "https://example.test/inspector.js"' in markup
+    assert '"export": "inspectorButton"' in markup
+    assert "await import(moduleUrls[definition.module])" in markup
+    assert "controlsModule.attachControls" in markup
+
+
+def test_display_controls_guide_uses_executable_tutorial_sections() -> None:
+    tutorial = _load_module(
+        "_display_controls_tutorial", DISPLAY_CONTROLS_TUTORIAL_PATH
+    )
+    source = DISPLAY_CONTROLS_GUIDE_PATH.read_text(encoding="utf-8")
+
+    assert tutorial.chart.to_dict()["assembly"] == "hg38"
+    for marker in (
+        "display-controls-basic-start",
+        "display-controls-override-start",
+        "display-controls-widget-start",
+        "display-controls-embed-options-start",
+        "display-controls-output-start",
+    ):
+        assert f":start-after: {marker}" in source
+
+    assert ":controls: svg,png,inspector" in source
+    assert ":controls: png" in source
 
 
 def test_tutorial_chart_target_rejects_paths() -> None:

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -30,6 +30,21 @@ def test_widget_rewrites_eager_records_as_a_named_dataset() -> None:
     assert widget.spec["datasets"] == {"__genome_spy_python_data_0": [{"x": 1, "y": 2}]}
     assert widget.dataset_names == ("__genome_spy_python_data_0",)
     assert "import(moduleUrl)" in widget._esm
+    assert widget.controls == ["svg", "png", "inspector"]
+    assert widget._control_definitions["png"] == {
+        "module": "core",
+        "export": "pngButton",
+    }
+
+
+def test_widget_accepts_selected_or_disabled_controls() -> None:
+    chart = gs.Chart().mark_point()
+
+    selected = chart.widget(controls=["png", "full-window"])
+    disabled = chart.widget(controls=False)
+
+    assert selected.controls == ["png", "full-window"]
+    assert disabled.controls == []
 
 
 def test_jupyter_chart_rewrites_raw_eager_spec_dict() -> None:

--- a/tests/widget.test.mjs
+++ b/tests/widget.test.mjs
@@ -6,9 +6,13 @@ const source = await readFile(
   new URL("../src/genome_spy/static/widget.js", import.meta.url),
   "utf8"
 );
-const { datasetApi, renderChart } = await import(
+const { datasetApi, mountControls, renderChart } = await import(
   `data:text/javascript,${encodeURIComponent(source)}`
 );
+
+function moduleUrl(source) {
+  return `data:text/javascript,${encodeURIComponent(source)}`;
+}
 
 class MockModel {
   constructor(values) {
@@ -83,6 +87,15 @@ function fixture(datasets = []) {
     bundle_url:
       "data:text/javascript,export const embed=(...args)=>globalThis.__widgetEmbed(...args)",
     embed_options: {},
+    controls: [],
+    _control_definitions: {
+      svg: { module: "core", export: "svgButton" },
+      png: { module: "core", export: "pngButton" },
+      inspector: { module: "inspector", export: "inspectorButton" },
+      "full-window": { module: "core", export: "fullWindowButton" },
+    },
+    controls_module_url: moduleUrl("export const attachControls=()=>null"),
+    inspector_module_url: moduleUrl("export const inspectorButton=()=>({})"),
     dataset_manifest: datasets,
     parameter_names: [],
     parameter_values: {},
@@ -179,6 +192,52 @@ test("datasetApi uses the top-level dataset API by default", () => {
   const api = { datasets: { load() {} } };
 
   assert.equal(datasetApi(api, descriptor("table", 0)), api.datasets);
+});
+
+test("mountControls maps requested names in display order", async () => {
+  let mounted;
+  globalThis.__widgetAttachControls = (_container, _api, options) => {
+    mounted = options.controls;
+    return { dispose() {} };
+  };
+  const controlsModuleUrl = moduleUrl(`
+    export const attachControls = (...args) => globalThis.__widgetAttachControls(...args);
+    export const svgButton = () => ({ name: "svg" });
+    export const pngButton = () => ({ name: "png" });
+    export const fullWindowButton = () => ({ name: "full-window" });
+  `);
+  const inspectorModuleUrl = moduleUrl(
+    'export const inspectorButton = () => ({ name: "inspector" });'
+  );
+
+  await mountControls({
+    container: {},
+    api: {},
+    names: ["png", "inspector", "svg", "full-window"],
+    definitions: fixture().model.get("_control_definitions"),
+    moduleUrls: {
+      core: controlsModuleUrl,
+      inspector: inspectorModuleUrl,
+    },
+  });
+
+  assert.deepEqual(
+    mounted.map((control) => control.name),
+    ["png", "inspector", "svg", "full-window"]
+  );
+  delete globalThis.__widgetAttachControls;
+});
+
+test("mountControls does not import modules when controls are disabled", async () => {
+  const mounted = await mountControls({
+    container: {},
+    api: {},
+    names: [],
+    definitions: {},
+    moduleUrls: { core: "invalid:controls" },
+  });
+
+  assert.equal(mounted, null);
 });
 
 test("datasetApi addresses a scoped declaration through its owner", () => {
@@ -421,6 +480,170 @@ test("structural rerender finalizes the old embed and reapplies current data", a
   assert.equal(second.loads.length, 1);
   testFixture.controller.abort();
   delete globalThis.__widgetEmbed;
+});
+
+test("control changes dispose controls before finalizing the old embed", async () => {
+  const testFixture = fixture();
+  testFixture.model.set("controls", ["png"]);
+  const events = [];
+  globalThis.__widgetAttachControls = () => {
+    events.push("attach");
+    return { dispose: () => events.push("dispose") };
+  };
+  testFixture.model.set(
+    "controls_module_url",
+    moduleUrl(`
+      export const attachControls = (...args) => globalThis.__widgetAttachControls(...args);
+      export const pngButton = () => ({ name: "png" });
+    `)
+  );
+  const first = apiFixture();
+  const second = apiFixture();
+  first.api.finalize = () => events.push("finalize-first");
+  second.api.finalize = () => events.push("finalize-second");
+  let calls = 0;
+  globalThis.__widgetEmbed = async () => [first.api, second.api][calls++];
+
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.model.set("controls", []);
+  testFixture.model.emit("change:controls");
+  await waitFor(() => calls === 2);
+
+  assert.deepEqual(events.slice(0, 3), ["attach", "dispose", "finalize-first"]);
+  testFixture.controller.abort();
+  assert.equal(events.at(-1), "finalize-second");
+  delete globalThis.__widgetAttachControls;
+  delete globalThis.__widgetEmbed;
+});
+
+test("a control module failure preserves the current embed", async () => {
+  const testFixture = fixture();
+  testFixture.model.set("controls", ["png"]);
+  testFixture.model.set("controls_module_url", "invalid:controls");
+  const rendered = apiFixture();
+  globalThis.__widgetEmbed = async () => rendered.api;
+
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+
+  assert.match(testFixture.model.get("error"), /controls failed to load/i);
+  assert.equal(rendered.finalized, 0);
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
+});
+
+test("successful initial data does not clear a control error", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  testFixture.model.set(entry.payload_trait, new Uint8Array([1]));
+  testFixture.model.set(entry.revision_trait, 1);
+  testFixture.model.set("controls", ["png"]);
+  testFixture.model.set("controls_module_url", "invalid:controls");
+  const rendered = apiFixture();
+  globalThis.__widgetEmbed = async () => rendered.api;
+
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+
+  assert.equal(rendered.loads.length, 1);
+  assert.match(testFixture.model.get("error"), /controls failed to load/i);
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
+});
+
+test("dataset recovery clears only its own error", async () => {
+  const entry = descriptor("table", 0);
+  const testFixture = fixture([entry]);
+  testFixture.model.set("controls", ["png"]);
+  testFixture.model.set("controls_module_url", "invalid:controls");
+  let attempts = 0;
+  const rendered = apiFixture({
+    load: async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error("decode failed");
+      }
+    },
+  });
+  globalThis.__widgetEmbed = async () => rendered.api;
+
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.model.set(entry.payload_trait, new Uint8Array([1]));
+  testFixture.model.set(entry.revision_trait, 1);
+  testFixture.model.emit(`change:${entry.payload_trait}`);
+  await waitFor(() => /decode failed/.test(testFixture.model.get("error")));
+  testFixture.model.set(entry.payload_trait, new Uint8Array([2]));
+  testFixture.model.set(entry.revision_trait, 2);
+  testFixture.model.emit(`change:${entry.payload_trait}`);
+  await waitFor(
+    () => attempts === 2 && !/decode failed/.test(testFixture.model.get("error"))
+  );
+
+  assert.doesNotMatch(testFixture.model.get("error"), /decode failed/);
+  assert.match(testFixture.model.get("error"), /controls failed to load/i);
+  testFixture.controller.abort();
+  delete globalThis.__widgetEmbed;
+});
+
+test("a throwing control disposer cannot block rerender finalization", async () => {
+  const testFixture = fixture();
+  testFixture.model.set("controls", ["png"]);
+  globalThis.__widgetAttachControls = () => ({
+    dispose() {
+      throw new Error("dispose failed");
+    },
+  });
+  testFixture.model.set(
+    "controls_module_url",
+    moduleUrl(`
+      export const attachControls = (...args) => globalThis.__widgetAttachControls(...args);
+      export const pngButton = () => ({ name: "png" });
+    `)
+  );
+  const first = apiFixture();
+  const second = apiFixture();
+  let calls = 0;
+  globalThis.__widgetEmbed = async () => [first.api, second.api][calls++];
+
+  await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+  testFixture.model.set("controls", []);
+  testFixture.model.emit("change:controls");
+  await waitFor(() => calls === 2);
+
+  assert.equal(first.finalized, 1);
+  assert.match(testFixture.model.get("error"), /dispose failed/);
+  testFixture.controller.abort();
+  delete globalThis.__widgetAttachControls;
+  delete globalThis.__widgetEmbed;
+});
+
+test("a throwing control disposer cannot block abort finalization", async () => {
+  const testFixture = fixture();
+  testFixture.model.set("controls", ["png"]);
+  globalThis.__widgetAttachControls = () => ({
+    dispose() {
+      throw new Error("dispose failed");
+    },
+  });
+  testFixture.model.set(
+    "controls_module_url",
+    moduleUrl(`
+      export const attachControls = (...args) => globalThis.__widgetAttachControls(...args);
+      export const pngButton = () => ({ name: "png" });
+    `)
+  );
+  const rendered = apiFixture();
+  globalThis.__widgetEmbed = async () => rendered.api;
+  const originalConsoleError = console.error;
+  console.error = () => {};
+
+  try {
+    await renderChart({ ...testFixture, signal: testFixture.controller.signal });
+    testFixture.controller.abort();
+    assert.equal(rendered.finalized, 1);
+  } finally {
+    console.error = originalConsoleError;
+    delete globalThis.__widgetAttachControls;
+    delete globalThis.__widgetEmbed;
+  }
 });
 
 test("disposal removes dataset listeners and finalizes the current embed", async () => {

--- a/tools/docs_gallery.py
+++ b/tools/docs_gallery.py
@@ -101,6 +101,21 @@ def default_bundle_url() -> str:
     return DEFAULT_EMBED_URL
 
 
+def default_control_config() -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+    """Return control definitions and pinned browser module URLs."""
+    _ensure_src_on_path()
+    from genome_spy._embed import (
+        DEFAULT_CONTROLS_MODULE_URL,
+        DEFAULT_INSPECTOR_MODULE_URL,
+        control_definitions,
+    )
+
+    return control_definitions(), {
+        "core": DEFAULT_CONTROLS_MODULE_URL,
+        "inspector": DEFAULT_INSPECTOR_MODULE_URL,
+    }
+
+
 def _load_module(path: Path) -> ModuleType:
     module_name = f"_gs_gallery_{path.stem}"
     spec = importlib.util.spec_from_file_location(module_name, path)


### PR DESCRIPTION
## Summary

Adds configurable GenomeSpy embed controls to rendered charts.

## Changes

- Shows export and inspector controls by default when GenomeSpy supports them.
- Adds a small Python API for choosing or disabling controls.
- Passes embed options consistently to HTML and notebook rendering.
- Documents display controls and their available options in the user guide.
- Adds coverage for chart serialization, widgets, and gallery rendering.